### PR TITLE
Add initial Ogmios v6 structs

### DIFF
--- a/chain_sync.go
+++ b/chain_sync.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gorilla/websocket"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 )
 
 // ChainSync provides control over a given ChainSync connection

--- a/chain_sync_test.go
+++ b/chain_sync_test.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 )
 
 func TestClient_ChainSync(t *testing.T) {

--- a/cmd/ogmigo/main.go
+++ b/cmd/ogmigo/main.go
@@ -26,7 +26,7 @@ import (
 	"sync/atomic"
 
 	"github.com/SundaeSwap-finance/ogmigo"
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 	"github.com/urfave/cli/v2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/SundaeSwap-finance/ogmigo
+module github.com/SundaeSwap-finance/ogmigo/v6
 
 go 1.19
 

--- a/ouroboros/chainsync/byronV6.go
+++ b/ouroboros/chainsync/byronV6.go
@@ -1,0 +1,91 @@
+// Copyright 2023 SundaeSwap Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Byron block code for Ogmios v6.
+// https://github.com/CardanoSolutions/ogmios/blob/d2b1d70ab5e676b5d053817d57ea8220f2b07317/docs/static/api/specification.yaml
+
+package chainsync
+
+import (
+	"encoding/json"
+)
+
+// BFT Block Root
+type ByronBlockBFTV6 struct {
+	Type                    string               `json:"type,omitempty"`
+	Era                     string               `json:"era,omitempty"`
+	ID                      string               `json:"id,omitempty"`
+	Ancestor                string               `json:"ancestor,omitempty"`
+	Height                  uint64               `json:"height,omitempty"`
+	Slot                    uint64               `json:"slot,omitempty"`
+	Size                    BlockSizeV6          `json:"size,omitempty"`
+	Transactions            []TxV6               `json:"transactions,omitempty"`
+	OperationalCertificates []json.RawMessage    `json:"operationalCertificates,omitempty"`
+	Protocol                ByronProtocolV6      `json:"protocol,omitempty"`
+	Issuer                  ByronBlockIssuerV6   `json:"issuer,omitempty"`
+	Delegate                ByronBlockDelegateV6 `json:"delegate,omitempty"`
+}
+
+// EBB Block Type
+type ByronBlockEBBV6 struct {
+	Type     string `json:"type,omitempty"`
+	Era      string `json:"era,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Ancestor string `json:"ancestor,omitempty"`
+	Height   uint64 `json:"height,omitempty"`
+}
+
+type ByronBlockDelegateV6 struct {
+	VerificationKey string
+}
+
+type ByronBlockIssuerV6 struct {
+	VerificationKey string
+}
+
+type ByronProtocolV6 struct {
+	Version  ProtocolVersion
+	Id       uint64 // aka magic
+	Software map[string]interface{}
+	Update   json.RawMessage
+}
+
+// TODO - Probably a better way to handle this. For now, just split up and handle
+// the differences manually. Also, we need to check the direction. Backward & forward
+// are different.
+type ResultByronEBBV6 struct {
+	Direction string           `json:"direction,omitempty" dynamodbav:"direction,omitempty"`
+	Block     *ByronBlockEBBV6 `json:"block,omitempty"     dynamodbav:"block,omitempty"`
+	Tip       *TipV6           `json:"tip,omitempty"       dynamodbav:"tip,omitempty"`
+}
+
+type ResultByronBFTV6 struct {
+	Direction string           `json:"direction,omitempty" dynamodbav:"direction,omitempty"`
+	Block     *ByronBlockBFTV6 `json:"block,omitempty"     dynamodbav:"block,omitempty"`
+	Tip       *TipV6           `json:"tip,omitempty"       dynamodbav:"tip,omitempty"`
+}
+
+type ResponseByronEBBV6 struct {
+	JsonRpc string            `json:"jsonrpc,omitempty" dynamodbav:"jsonrpc,omitempty"`
+	Method  string            `json:"method,omitempty"  dynamodbav:"method,omitempty"`
+	Result  *ResultByronEBBV6 `json:"result,omitempty"  dynamodbav:"result,omitempty"`
+	ID      json.RawMessage   `json:"id,omitempty"      dynamodbav:"id,omitempty"`
+}
+
+type ResponseByronBFTV6 struct {
+	JsonRpc string            `json:"jsonrpc,omitempty" dynamodbav:"jsonrpc,omitempty"`
+	Method  string            `json:"method,omitempty"  dynamodbav:"method,omitempty"`
+	Result  *ResultByronBFTV6 `json:"result,omitempty"  dynamodbav:"result,omitempty"`
+	ID      json.RawMessage   `json:"id,omitempty"      dynamodbav:"id,omitempty"`
+}

--- a/ouroboros/chainsync/types.go
+++ b/ouroboros/chainsync/types.go
@@ -30,7 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/fxamacker/cbor/v2"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync/num"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync/num"
 )
 
 var (

--- a/ouroboros/chainsync/typesV6.go
+++ b/ouroboros/chainsync/typesV6.go
@@ -1,0 +1,157 @@
+// Copyright 2021 Matt Ho
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync/num"
+)
+
+// TODO - Probably a better way to handle this. For now, just split up and handle
+// the differences manually. Also, we need to check the direction. Backward & forward
+// are different.
+type ResultPraosV6 struct {
+	Direction string   `json:"direction,omitempty" dynamodbav:"direction,omitempty"`
+	Block     *BlockV6 `json:"block,omitempty"     dynamodbav:"block,omitempty"`
+	Tip       *TipV6   `json:"tip,omitempty"       dynamodbav:"tip,omitempty"`
+}
+
+type ResponsePraosV6 struct {
+	JsonRpc string          `json:"jsonrpc,omitempty" dynamodbav:"jsonrpc,omitempty"`
+	Method  string          `json:"method,omitempty"  dynamodbav:"method,omitempty"`
+	Result  *ResultPraosV6  `json:"result,omitempty"  dynamodbav:"result,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"      dynamodbav:"id,omitempty"`
+}
+
+type BlockV6 struct {
+	Type         string        `json:"type,omitempty"`
+	Era          string        `json:"era,omitempty"`
+	ID           string        `json:"id,omitempty"`
+	Ancestor     string        `json:"ancestor,omitempty"`
+	Nonce        NonceV6       `json:"nonce,omitempty"`
+	Height       uint64        `json:"height,omitempty"`
+	Size         BlockSizeV6   `json:"size,omitempty"`
+	Slot         uint64        `json:"slot,omitempty"`
+	Transactions []TxV6        `json:"transactions,omitempty"`
+	Protocol     ProtocolV6    `json:"protocol,omitempty"`
+	Issuer       BlockIssuerV6 `json:"issuer,omitempty"`
+}
+
+type BlockIssuerV6 struct {
+	VerificationKey        string        `json:"verificationKey,omitempty"`
+	VrfVerificationKey     string        `json:"vrfVerificationKey,omitempty"`
+	OperationalCertificate OpCertV6      `json:"operationalCertificate,omitempty"`
+	LeaderValue            LeaderValueV6 `json:"leaderValue,omitempty"`
+}
+
+type OpCertV6 struct {
+	Count uint64 `json:"count,omitempty"`
+	Kes   KesV6  `json:"kes,omitempty"`
+}
+
+type LeaderValueV6 struct {
+	Proof  string `json:"proof,omitempty"`
+	Output string `json:"output,omitempty"`
+}
+
+type KesV6 struct {
+	Period          uint64 `json:"period,omitempty"`
+	VerificationKey string `json:"verificationKey,omitempty"`
+}
+
+type ProtocolV6 struct {
+	Version ProtocolVersion `json:"version,omitempty" dynamodbav:"version,omitempty"`
+}
+
+type NonceV6 struct {
+	Output string `json:"output,omitempty" dynamodbav:"slot,omitempty"`
+	Proof  string `json:"proof,omitempty"  dynamodbav:"slot,omitempty"`
+}
+
+type BlockSizeV6 struct {
+	Bytes int64
+}
+
+type TxV6 struct {
+	ID                       string                `json:"id,omitempty"                       dynamodbav:"id,omitempty"`
+	Spends                   string                `json:"spends,omitempty"                   dynamodbav:"spends,omitempty"`
+	Inputs                   []TxInV6              `json:"inputs,omitempty"                   dynamodbav:"inputs,omitempty"`
+	References               []TxInV6              `json:"references,omitempty"               dynamodbav:"references,omitempty"`
+	Collaterals              []TxInV6              `json:"collaterals,omitempty"              dynamodbav:"collaterals,omitempty"`
+	TotalCollateral          *int64                `json:"totalCollateral,omitempty"          dynamodbav:"totalCollateral,omitempty"`
+	CollateralReturn         *TxOutV6              `json:"collateralReturn,omitempty"         dynamodbav:"collateralReturn,omitempty"`
+	Outputs                  TxOutsV6              `json:"outputs,omitempty"                  dynamodbav:"outputs,omitempty"`
+	Certificates             []json.RawMessage     `json:"certificates,omitempty"             dynamodbav:"certificates,omitempty"`
+	Withdrawals              map[string]LovelaceV6 `json:"withdrawals,omitempty"              dynamodbav:"withdrawals,omitempty"`
+	Fee                      LovelaceV6            `json:"fee,omitempty"                      dynamodbav:"fee,omitempty"`
+	ValidityInterval         ValidityInterval      `json:"validityInterval"                   dynamodbav:"validityInterval,omitempty"`
+	Mint                     []DoubleNestedInteger `json:"mint,omitempty"                     dynamodbav:"mint,omitempty"`
+	Network                  json.RawMessage       `json:"network,omitempty"                  dynamodbav:"network,omitempty"`
+	ScriptIntegrityHash      string                `json:"scriptIntegrityHash,omitempty"      dynamodbav:"scriptIntegrityHash,omitempty"`
+	RequiredExtraSignatories []string              `json:"requiredExtraSignatories,omitempty" dynamodbav:"requiredExtraSignatories,omitempty"`
+	RequiredExtraScripts     []string              `json:"requiredExtraScripts,omitempty"     dynamodbav:"requiredExtraScripts,omitempty"`
+	Proposals                json.RawMessage       `json:"proposals,omitempty"                dynamodbav:"proposals,omitempty"`
+	Votes                    json.RawMessage       `json:"votes,omitempty"                    dynamodbav:"votes,omitempty"`
+	Metadata                 json.RawMessage       `json:"metadata,omitempty"                 dynamodbav:"metadata,omitempty"`
+	Signatories              []json.RawMessage     `json:"signatories,omitempty"              dynamodbav:"signatories,omitempty"`
+	Scripts                  json.RawMessage       `json:"scripts,omitempty"                  dynamodbav:"scripts,omitempty"`
+	Datums                   Datums                `json:"datums,omitempty"                   dynamodbav:"datums,omitempty"`
+	Redeemers                json.RawMessage       `json:"redeemers,omitempty"                dynamodbav:"redeemers,omitempty"`
+	CBOR                     string                `json:"cbor,omitempty"                     dynamodbav:"cbor,omitempty"`
+}
+
+type TxInV6 struct {
+	Transaction TxInIdV6 `json:"transaction"    dynamodbav:"transaction"`
+	Index       int      `json:"index" dynamodbav:"index"`
+}
+
+type TxInIdV6 struct {
+	ID string `json:"id" dynamodbav:"id"`
+}
+
+func (t TxInV6) String() string {
+	return t.Transaction.ID + "#" + strconv.Itoa(t.Index)
+}
+
+type TxOutV6 struct {
+	Address   string          `json:"address,omitempty"   dynamodbav:"address,omitempty"`
+	Value     ValueV6         `json:"value,omitempty"     dynamodbav:"value,omitempty"`
+	DatumHash string          `json:"datumHash,omitempty" dynamodbav:"datumHash,omitempty"`
+	Datum     string          `json:"datum,omitempty"     dynamodbav:"datum,omitempty"`
+	Script    json.RawMessage `json:"script,omitempty"    dynamodbav:"script,omitempty"`
+}
+
+type ValueV6 map[string]map[string]uint64
+
+func (v ValueV6) Lovelace() uint64 {
+	return v["ada"]["lovelace"]
+}
+
+type TxOutsV6 []TxOutV6
+
+type LovelaceV6 struct {
+	Lovelace num.Int `json:"lovelace,omitempty"  dynamodbav:"lovelace,omitempty"`
+	Extras   []DoubleNestedInteger
+}
+
+type DoubleNestedInteger map[string]map[string]num.Int
+
+type TipV6 struct {
+	Slot   uint64 `json:"slot,omitempty"   dynamodbav:"slot,omitempty"`
+	ID     string `json:"id,omitempty"     dynamodbav:"id,omitempty"`
+	Height uint64 `json:"height,omitempty" dynamodbav:"height,omitempty"`
+}

--- a/ouroboros/chainsync/typesV6_test.go
+++ b/ouroboros/chainsync/typesV6_test.go
@@ -1,0 +1,443 @@
+// Copyright 2021 Matt Ho
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"bufio" // REMOVE LATER?
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUnmarshalV6(t *testing.T) {
+	err := filepath.Walk("../../ext/ogmios/server/test/vectors/NextBlockResponse", assertStructMatchesSchemaV6(t))
+	if err != nil {
+		t.Fatalf("got %v; want nil", err)
+	}
+	decoder := json.NewDecoder(nil)
+	decoder.DisallowUnknownFields()
+}
+
+func find(s string, d map[string]interface{}) string {
+	r := ""
+	for k, v := range d {
+		if k == s {
+			r += fmt.Sprintf("%s", v) + ";"
+		}
+		if c, ok := v.(map[string]interface{}); ok {
+			r += find(s, c)
+		}
+	}
+	return r
+}
+
+func assertStructMatchesSchemaV6(t *testing.T) filepath.WalkFunc {
+	return func(path string, info fs.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		path, _ = filepath.Abs(path)
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("got %v; want nil", err)
+		}
+		defer f.Close()
+
+		d := map[string]interface{}{}
+		stat, err := f.Stat()
+		bs := make([]byte, stat.Size())
+		_, err = bufio.NewReader(f).Read(bs)
+		json.Unmarshal(bs, &d)
+		blockEra := find("era", d)
+		blockType := find("type", d)
+		t.Logf("DEBUG - %s: %s\n", "era", blockEra)
+		t.Logf("DEBUG - %s: %s\n", "type", blockType)
+		f.Seek(0, io.SeekStart)
+		decoder := json.NewDecoder(f)
+		decoder.DisallowUnknownFields()
+		if blockEra == "Byron" && blockType == "EBB" {
+			err = decoder.Decode(&ResponseByronEBBV6{})
+		} else if blockEra == "Byron" && blockType == "BFT" {
+			err = decoder.Decode(&ResponseByronBFTV6{})
+		} else {
+			err = decoder.Decode(&ResponsePraosV6{})
+		}
+
+		if err != nil {
+			t.Fatalf("got %v; want nil: %v", err, fmt.Sprintf("struct did not match schema for file, %v", path))
+		}
+
+		return nil
+	}
+}
+
+func TestByronBFT(t *testing.T) {
+	data := `{
+		"jsonrpc": "2.0",
+		"method": "nextBlock",
+		"result": {
+			"direction": "forward",
+			"block": {
+				"type": "bft",
+				"era": "byron",
+				"id": "21d89eb76817a3ea1b9df033526f833cef18c4c762c356922eafb148bc14001e",
+				"ancestor": "aad78a13b50a014a24633c7d44fd8f8d18f67bbb3fa9cbcedf834ac899759dcd",
+				"height": 6574977808651210019,
+				"slot": 3294403856197716808,
+				"size": {
+					"bytes": 921
+				},
+				"transactions": [],
+				"operationalCertificates": [],
+				"protocol": {
+					"id": 100,
+					"version": {
+						"major": 892,
+						"minor": 51768,
+						"patch": 35
+					},
+					"software": {
+						"appName": "sDSF7",
+						"number": 4117586641
+					},
+					"update": {
+						"proposal": {
+							"version": {
+								"major": 29680,
+								"minor": 55074,
+								"patch": 14
+							},
+							"software": {
+								"appName": "",
+								"number": 1115902224
+							},
+							"parameters": {
+								"scriptVersion": 25799,
+								"slotDuration": 66450280671243551,
+								"maxBlockBodySize": {
+									"bytes": 6332592073220457
+								},
+								"maxTransactionSize": {
+									"bytes": 81061672327968174
+								},
+								"maxUpdateProposalSize": {
+									"bytes": 172822501139406362
+								},
+								"multiPartyComputationThreshold": "288921139725109/500000000000000",
+								"heavyDelegationThreshold": "138029086789251/200000000000000",
+								"updateProposalThreshold": "294859239649641/500000000000000",
+								"updateProposalTimeToLive": 16087585201267149304,
+								"unlockStakeEpoch": 2481827810661368817,
+								"softForkInitThreshold": "187743902107349/200000000000000",
+								"softForkMinThreshold": "4036481357189/500000000000000",
+								"softForkDecrementThreshold": "13675322648881/40000000000000"
+							},
+							"metadata": {}
+						},
+						"votes": []
+					}
+				},
+				"issuer": {
+					"verificationKey": "8ece824656e8007745e655f080ced6a86012a26cd667232e0b810b1dd2d6555cb8a2405a55c46ce9fb0346bffb6cd7a8cd294d8950eeba7f6ba9c4fe26256b24"
+				},
+				"delegate": {
+					"verificationKey": "8ece824656e8007745e655f080ced6a86012a26cd667232e0b810b1dd2d6555cb8a2405a55c46ce9fb0346bffb6cd7a8cd294d8950eeba7f6ba9c4fe26256b24"
+				}
+			},
+			"tip": {
+				"slot": 46734,
+				"id": "4cbfd2af37df07a6bab5850b8122ed56708b4b57676cd23a6b564d33907a52e9",
+				"height": 3642099
+			}
+		},
+		"id": null
+	}
+`
+	var response ResponseByronBFTV6
+	err := json.Unmarshal([]byte(data), &response)
+	if err != nil {
+		t.Fatalf("error unmarshalling response: %v", err)
+	}
+}
+
+func TestByronEBB(t *testing.T) {
+	data := `{
+		"jsonrpc": "2.0",
+		"method": "nextBlock",
+		"result": {
+			"direction": "forward",
+			"block": {
+				"type": "ebb",
+				"era": "byron",
+				"height": 13521870305663481883,
+				"id": "88cb33510fb3f8b878f44523163b00b619d82957d28726230f7214a36b49e2e4",
+				"ancestor": "aad78a13b50a014a24633c7d44fd8f8d18f67bbb3fa9cbcedf834ac899759dcd"
+			},
+			"tip": {
+				"slot": 58655,
+				"id": "d15959c51e4e83b791a56fac47ecb0b7dfc7a65e7c062d8ea3ae97f6635db1dc",
+				"height": 1038970
+			}
+		},
+		"id": null
+	}
+`
+	var response ResponseByronEBBV6
+	err := json.Unmarshal([]byte(data), &response)
+	if err != nil {
+		t.Fatalf("error unmarshalling response: %v", err)
+	}
+}
+
+func TestPraos(t *testing.T) {
+	data := `{
+		"jsonrpc": "2.0",
+		"method": "nextBlock",
+		"result": {
+			"direction": "forward",
+			"block": {
+				"type": "praos",
+				"era": "allegra",
+				"id": "109dab4b2e94ebb0e1ad5bafa335392ab6d4e9ea01d7878087f825ad4a9cdeb3",
+				"ancestor": "82a795bf5dcba27286949627170b40e765e3e1da7d90d20a9bf1075d9517c747",
+				"nonce": {
+					"output": "02020202000100020001010000010100010201000202010102000101010000000202000200020000000100020201010100020002010201010000010102000100",
+					"proof": "98fbb316e8bbd717ca27325d44eaaf90867b8351a7b9839a1b19e8e6b416791363470f0709ba78f6a5c4f50dee2e6295aa04a4fd125143b0dfdbed7422b6efe49ad4b94c34eb7f434c486e1d803e0b0a"
+				},
+				"height": 0,
+				"slot": 2,
+				"issuer": {
+					"verificationKey": "948b49ced8f0316e7d33a8de788eb3ba3ea88deb2716bf185cae5820591fdabf",
+					"vrfVerificationKey": "224655a70fb7d8cb8f900c97f16cfc45645124a1d388b6eaa2c4511ef5da79d8",
+					"leaderValue": {
+						"output": "00000102020200010101020101010102020202000001000100010001010001020101000202020200000201000001010002020200010202000102010000020000",
+						"proof": "a2876927ad069b694d87cf070e49f7786ba1312b25dcc501657b545a1297fe0db1627d96d6a3ca7bbf4e8ede19885e4a164bd8d4e31d747fcd05ac63f17af4a58503a6417ce9554724f30b7dada17f05"
+					},
+					"operationalCertificate": {
+						"count": 0,
+						"kes": {
+							"period": 2,
+							"verificationKey": "b39372534cb0636dfdfcab8e7726aa7bb3160ef9b640a52bb0a043093baa613d"
+						}
+					}
+				},
+				"protocol": {
+					"version": {
+						"major": 4,
+						"minor": 1
+					}
+				},
+				"size": {
+					"bytes": 1
+				},
+				"transactions": [
+					{
+						"id": "2bd3c9bb48d587f9a6bccb8230110ba0c536aa05c5966b1a63052b26775db4f4",
+						"spends": "inputs",
+						"inputs": [
+							{
+								"transaction": {
+									"id": "7525e434d3b951d3499b87f8cbd02ed0ebb0c0248343af568c29d15e79825bd8"
+								},
+								"index": 0
+							}
+						],
+						"outputs": [
+							{
+								"address": "addr_test1ypt3trk84kyekn6zy936rz4aetlndlhkv35ztmfv57te3uzsahhjajdzftrmkmtfnrs5ryefgug64maldke5qjd0yvcs2v68ny",
+								"value": {
+									"ada": {
+										"lovelace": 987617
+									}
+								}
+							},
+							{
+								"address": "EqGAuA8vHnPEVahYhLV7WYBL4EeaZuTMttq6h5Xc4hHvYpUyyMu1EcdXNKf85Xb4G3hGswH8tqbY6pGhunn1yKrxmfV8aDW4sFfks1ruLM2icn93HRDrwra",
+								"value": {
+									"ada": {
+										"lovelace": 66410
+									}
+								}
+							}
+						],
+						"withdrawals": {
+							"stake_test17re7uuh9zercugh782esdhp4lspnz6k7sspk7254yagzpwq83d45f": {
+								"lovelace": 37534
+							}
+						},
+						"fee": {
+							"lovelace": 737494
+						},
+						"validityInterval": {
+							"invalidBefore": 1,
+							"invalidAfter": 1
+						},
+						"signatories": [
+							{
+								"key": "634757c7aecfd4d9b6ba22b68d6410484e6427ac05e2e605e633f19617d1cecb",
+								"signature": "7a9aafd169b23153442311f068b3d3ae782d9a7c95f60694453042b4e3725697ca2585270f5e6aa53b914c6f2c79ae363455e326f527bd5fcda627fb3a99dcdc",
+								"chainCode": "11de49",
+								"addressAttributes": "9068"
+							},
+							{
+								"key": "d3688e9746e6fa68a20fa7a376a947b1adb53b44da72b02eb6d5a00f9bf34fc5",
+								"signature": "b16448d177014e269064b8ebc2e6b192ed03b7978fe4278d68c4716a68840664d005aa649e675f0569ef8906df21a5514c00eea3df676bcae4f2d1bad9f4f3b6",
+								"chainCode": "07",
+								"addressAttributes": "53"
+							},
+							{
+								"key": "7658aec9e30d35256940dab38397becb6712c04f4d79596b0c99dbb6d00892da",
+								"signature": "c6215f8eacdbcf09cbb440f5a1bf2553344873b1fd97175c06ccb3920546ee4f40523b58ae2dee86cf526771cc995098b2e015c5af54af36d5c5975170801cbc",
+								"chainCode": "a7",
+								"addressAttributes": "a993bd"
+							}
+						],
+						"scripts": {
+							"5c6dfd90190d6c66547da3debf3d8967340b270feb3f6cf5a5f8cab8": {
+								"language": "native",
+								"json": {
+									"clause": "after",
+									"slot": 2
+								}
+							},
+							"9db4dcc531262ba3db77abdb21315f4f68b1d460a74bd87a9ce50ef7": {
+								"language": "native",
+								"json": {
+									"clause": "some",
+									"atLeast": 4,
+									"from": [
+										{
+											"clause": "any",
+											"from": [
+												{
+													"clause": "all",
+													"from": [
+														{
+															"clause": "signature",
+															"from": "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54"
+														}
+													]
+												},
+												{
+													"clause": "after",
+													"slot": 8
+												},
+												{
+													"clause": "before",
+													"slot": 16
+												}
+											]
+										},
+										{
+											"clause": "after",
+											"slot": 14
+										},
+										{
+											"clause": "any",
+											"from": [
+												{
+													"clause": "signature",
+													"from": "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7"
+												}
+											]
+										},
+										{
+											"clause": "all",
+											"from": [
+												{
+													"clause": "signature",
+													"from": "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4"
+												},
+												{
+													"clause": "before",
+													"slot": 6
+												},
+												{
+													"clause": "some",
+													"atLeast": 2,
+													"from": [
+														{
+															"clause": "signature",
+															"from": "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e"
+														},
+														{
+															"clause": "signature",
+															"from": "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a"
+														},
+														{
+															"clause": "signature",
+															"from": "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56"
+														}
+													]
+												},
+												{
+													"clause": "before",
+													"slot": 0
+												},
+												{
+													"clause": "any",
+													"from": [
+														{
+															"clause": "signature",
+															"from": "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a"
+														}
+													]
+												}
+											]
+										},
+										{
+											"clause": "signature",
+											"from": "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541"
+										}
+									]
+								}
+							},
+							"acfae5054c2216d7b6e1985637d35fbe4f0520bc84f0e8c60b9a9789": {
+								"language": "native",
+								"json": {
+									"clause": "some",
+									"atLeast": 1,
+									"from": [
+										{
+											"clause": "before",
+											"slot": 16
+										}
+									]
+								}
+							}
+						}
+					}
+				]
+			},
+			"tip": {
+				"slot": 47137,
+				"id": "12a3b5451db4b82932f1e4045e1be8a829bf8d30f61010cfac42781f29a47564",
+				"height": 8953265
+			}
+		},
+		"id": "H07GyFhAxTb4"
+	}
+`
+	var response ResponsePraosV6
+	err := json.Unmarshal([]byte(data), &response)
+	if err != nil {
+		t.Fatalf("error unmarshalling response: %v", err)
+	}
+}

--- a/ouroboros/statequery/types.go
+++ b/ouroboros/statequery/types.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 )
 
 type EraStart struct {

--- a/ouroboros/statequery/types_test.go
+++ b/ouroboros/statequery/types_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync/num"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync/num"
 )
 
 func TestUtxo_MarshalJSON(t *testing.T) {

--- a/state_query.go
+++ b/state_query.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/statequery"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/statequery"
 )
 
 func (c *Client) ChainTip(ctx context.Context) (chainsync.Point, error) {

--- a/store.go
+++ b/store.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 )
 
 // Store allows points to be saved and retrieved to allow graceful recovery

--- a/store/badgerstore/store.go
+++ b/store/badgerstore/store.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 )
 
 type Store struct {

--- a/store/badgerstore/store_test.go
+++ b/store/badgerstore/store_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 	"github.com/dgraph-io/badger/v3"
 )
 

--- a/store_test.go
+++ b/store_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SundaeSwap-finance/ogmigo/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 )
 
 func TestNewLoggingStore(t *testing.T) {


### PR DESCRIPTION
- Add v6 structs related to blocks and transactions including Byron-specific code.
- Bump the major version of the library.

NOTE: https://github.com/CardanoSolutions/ogmios/blob/master/architectural-decisions/accepted/017-api-version-6-major-rewrite.md was used as a guide but appears to have minor differences compared to Ogmios code. When differences were noticed, the code won the day.