### PR TITLE
Fix crashes for Must methods in Ogmigo

### DIFF
--- a/ouroboros/chainsync/compatibility/types.go
+++ b/ouroboros/chainsync/compatibility/types.go
@@ -253,29 +253,14 @@ func (r CompatibleResponsePraos) MustFindIntersectResult() CompatibleResultFindI
 	if r.Method != chainsync.FindIntersectionMethod {
 		panic(fmt.Errorf("must only use *Must* methods after switching on the findIntersection method; called on %v", r.Method))
 	}
-	return r.Result.(CompatibleResultFindIntersection)
+	return CompatibleResultFindIntersection(r.Result.(chainsync.ResultFindIntersectionPraos))
 }
 
 func (r CompatibleResponsePraos) MustNextBlockResult() CompatibleResultNextBlock {
 	if r.Method != chainsync.NextBlockMethod {
 		panic(fmt.Errorf("must only use *Must* methods after switching on the nextBlock method; called on %v", r.Method))
 	}
-	fmt.Printf("type of r.Result is %T\n", r.Result)
-	return r.Result.(CompatibleResultNextBlock)
-}
-
-// With v5, the Result type was explicitly marked in the JSON from Ogmigo. This made
-// JSON marshaling easy to consolidate. With v6, we don't have that luxury. The
-// workaround is to switch on the Method and cast the Result bytes.
-func (c CompatibleResponsePraos) GetResultBytes() (data []byte, err error) {
-	switch c.Method {
-	case chainsync.FindIntersectionMethod, chainsync.FindIntersectMethod:
-		return json.Marshal(c.Result.(chainsync.ResultFindIntersectionPraos))
-	case chainsync.NextBlockMethod, chainsync.RequestNextMethod:
-		return json.Marshal(c.Result.(chainsync.ResultNextBlockPraos))
-	default:
-		return nil, error(fmt.Errorf("unsupported method: %v", c.Method))
-	}
+	return CompatibleResultNextBlock(r.Result.(chainsync.ResultNextBlockPraos))
 }
 
 func ConvertPointStructV5ToV6(p v5.PointStructV5) chainsync.PointStruct {

--- a/ouroboros/chainsync/types.go
+++ b/ouroboros/chainsync/types.go
@@ -480,7 +480,6 @@ func (r ResponsePraos) MustNextBlockResult() ResultNextBlockPraos {
 	if r.Method != NextBlockMethod {
 		panic(fmt.Errorf("must only use *Must* methods after switching on the nextBlock method; called on %v", r.Method))
 	}
-	fmt.Printf("type of r.Result is %T\n", r.Result)
 	return r.Result.(ResultNextBlockPraos)
 }
 


### PR DESCRIPTION
- Fix errant casting to prevent crashes.
- Remove an extra debug line that made library usage a bit annoying.