### PR TITLE
[SB-1201] Move block eras to shared module

### DIFF
--- a/ouroboros/chainsync/v5/types.go
+++ b/ouroboros/chainsync/v5/types.go
@@ -33,23 +33,6 @@ var (
 	bNil = []byte("nil")
 )
 
-// Unfortunately, due to how v5 data is formatted on the wire and stored by Ogmigo,
-// we have to use other data to determine the era. Because the protocol version can
-// be determined before a fork, unlike the slot number, we use the protocol version.
-// This will make it easier to add support for future forks before the fork occurs,
-// while also supporting testnet and other networks that use the same versioning.
-var majorEras = map[uint32]string{
-	0: "byron",
-	1: "byron",
-	2: "shelley",
-	3: "allegra",
-	4: "mary",
-	5: "mary",
-	6: "alonzo",
-	7: "babbage",
-	8: "conway",
-}
-
 type IntersectionFound struct {
 	Point PointV5
 	Tip   TipV5
@@ -334,9 +317,14 @@ func (b BlockV5) ConvertToV6() chainsync.Block {
 		LeaderValue:            leaderValue,
 	}
 
+	// Unfortunately, due to how v5 data is formatted on the wire and stored by Ogmigo,
+	// we have to use other data to determine the era. Because the protocol version can
+	// be determined before a fork, unlike the slot number, we use the protocol version.
+	// This will make it easier to add support for future forks before the fork occurs,
+	// while also supporting testnet and other networks that use the same versioning.
 	b6 := chainsync.Block{
 		Type:         "praos",
-		Era:          majorEras[majorVer],
+		Era:          shared.MajorEras[majorVer],
 		ID:           b.HeaderHash,
 		Ancestor:     b.Header.PrevHash,
 		Nonce:        nonce,

--- a/ouroboros/shared/eras.go
+++ b/ouroboros/shared/eras.go
@@ -1,0 +1,21 @@
+package shared
+
+var ByronEra = "byron"
+var ShelleyEra = "shelley"
+var AllegraEra = "allegra"
+var MaryEra = "mary"
+var AlonzoEra = "alonzo"
+var BabbageEra = "babbage"
+var ConwayEra = "conway"
+
+var MajorEras = map[uint32]string{
+	0: ByronEra,
+	1: ByronEra,
+	2: ShelleyEra,
+	3: AllegraEra,
+	4: MaryEra,
+	5: MaryEra,
+	6: AlonzoEra,
+	7: BabbageEra,
+	8: ConwayEra,
+}

--- a/state_query_test.go
+++ b/state_query_test.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
+	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/shared"
 )
 
 func TestClient_ChainTip(t *testing.T) {
@@ -102,21 +104,21 @@ func TestClient_CurrentProtocolParameters(t *testing.T) {
 }
 
 func TestClient_GenesisConfig(t *testing.T) {
-       endpoint := os.Getenv("OGMIOS")
-       if endpoint == "" {
-               t.SkipNow()
-       }
+	endpoint := os.Getenv("OGMIOS")
+	if endpoint == "" {
+		t.SkipNow()
+	}
 
-       ctx := context.Background()
-       client := New(WithEndpoint(endpoint), WithLogger(DefaultLogger))
-       params, err := client.GenesisConfig(ctx, "shelley")
-       if err != nil {
-               t.Fatalf("got %#v; want nil", err)
-       }
+	ctx := context.Background()
+	client := New(WithEndpoint(endpoint), WithLogger(DefaultLogger))
+	params, err := client.GenesisConfig(ctx, shared.ShelleyEra)
+	if err != nil {
+		t.Fatalf("got %#v; want nil", err)
+	}
 
-       encoder := json.NewEncoder(os.Stdout)
-       encoder.SetIndent("", "  ")
-       _ = encoder.Encode(params)
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	_ = encoder.Encode(params)
 }
 
 func TestClient_EraStart(t *testing.T) {


### PR DESCRIPTION
We should have common era strings made available publicly. Rearrange the code to make this work.