### PR TITLE
Minor fixups to Utxo types

### DIFF
--- a/cmd/test_client/main.go
+++ b/cmd/test_client/main.go
@@ -108,7 +108,7 @@ func main() {
 	// 	fmt.Printf("GOT THE ADDRESSES - ", utxos_addr[1].Address, " - ", utxos_addr[1].Index)
 	// }
 
-	// id1 := chainsync.UtxoTxID{ID: "16fe7982c416714c22af503165eb9a49eaa55575b9c2e9deb2c400ed4592da03"}
+	// id1 := shared.UtxoTxID{ID: "16fe7982c416714c22af503165eb9a49eaa55575b9c2e9deb2c400ed4592da03"}
 	// query1 := chainsync.TxInQuery{Transaction: id1, Index: 0}
 
 	// utxos_txin, err := my_client.UtxosByTxIn(ctx, query1)

--- a/ouroboros/chainsync/types.go
+++ b/ouroboros/chainsync/types.go
@@ -523,12 +523,8 @@ type TxOuts []TxOut
 type Datums map[string]string
 
 type TxInQuery struct {
-	Transaction UtxoTxID `json:"transaction"  dynamodbav:"transaction"`
-	Index       uint32   `json:"index" dynamodbav:"index"`
-}
-
-type UtxoTxID struct {
-	ID string `json:"id"`
+	Transaction shared.UtxoTxID `json:"transaction"  dynamodbav:"transaction"`
+	Index       uint32          `json:"index" dynamodbav:"index"`
 }
 
 func (d *Datums) UnmarshalJSON(i []byte) error {

--- a/ouroboros/shared/utxo.go
+++ b/ouroboros/shared/utxo.go
@@ -1,0 +1,5 @@
+package shared
+
+type UtxoTxID struct {
+	ID string `json:"id"`
+}

--- a/ouroboros/shared/value.go
+++ b/ouroboros/shared/value.go
@@ -69,10 +69,10 @@ func Enough(have Value, want Value) (bool, error) {
 
 func (v Value) AddAsset(coins ...Coin) {
 	for _, coin := range coins {
-		if _, ok := v[coin.assetId.PolicyID()]; !ok {
-			v[coin.assetId.PolicyID()] = map[string]num.Int{}
+		if _, ok := v[coin.AssetId.PolicyID()]; !ok {
+			v[coin.AssetId.PolicyID()] = map[string]num.Int{}
 		}
-		v[coin.assetId.PolicyID()][coin.assetId.AssetName()] = v[coin.assetId.PolicyID()][coin.assetId.AssetName()].Add(coin.amount)
+		v[coin.AssetId.PolicyID()][coin.AssetId.AssetName()] = v[coin.AssetId.PolicyID()][coin.AssetId.AssetName()].Add(coin.Amount)
 	}
 }
 
@@ -102,8 +102,8 @@ func (v Value) AssetsExceptAda() Value {
 }
 
 type Coin struct {
-	assetId AssetID
-	amount  num.Int
+	AssetId AssetID
+	Amount  num.Int
 }
 
 func ValueFromCoins(coins ...Coin) Value {

--- a/ouroboros/statequery/types.go
+++ b/ouroboros/statequery/types.go
@@ -21,16 +21,12 @@ type EraMilliseconds struct {
 	Milliseconds big.Int `json:"milliseconds"`
 }
 
-type Utxo struct {
-	Transaction UtxoTxID        `json:"transaction"`
-	Index       uint32          `json:"index"`
-	Address     string          `json:"address"`
-	Value       shared.Value    `json:"value"`
-	DatumHash   string          `json:"datumHash,omitempty"`
-	Datum       string          `json:"datum,omitempty"`
-	Script      json.RawMessage `json:"script,omitempty"`
-}
-
-type UtxoTxID struct {
-	ID string `json:"id"`
+type UtxoData struct {
+	InTransaction shared.UtxoTxID `json:"transaction"`
+	InIndex       uint32          `json:"index"`
+	OutAddress    string          `json:"address"`
+	OutValue      shared.Value    `json:"value"`
+	OutDatumHash  string          `json:"datumHash,omitempty"`
+	OutDatum      string          `json:"datum,omitempty"`
+	OutScript     json.RawMessage `json:"script,omitempty"`
 }

--- a/ouroboros/statequery/types.go
+++ b/ouroboros/statequery/types.go
@@ -21,12 +21,15 @@ type EraMilliseconds struct {
 	Milliseconds big.Int `json:"milliseconds"`
 }
 
-type UtxoData struct {
-	InTransaction shared.UtxoTxID `json:"transaction"`
-	InIndex       uint32          `json:"index"`
-	OutAddress    string          `json:"address"`
-	OutValue      shared.Value    `json:"value"`
-	OutDatumHash  string          `json:"datumHash,omitempty"`
-	OutDatum      string          `json:"datum,omitempty"`
-	OutScript     json.RawMessage `json:"script,omitempty"`
+type TxOut struct {
+	// Fields identifying the TxOut.
+	Transaction shared.UtxoTxID `json:"transaction"`
+	Index       uint32          `json:"index"`
+
+	// On-chain TxOut fields.
+	Address   string          `json:"address"`
+	Value     shared.Value    `json:"value"`
+	DatumHash string          `json:"datumHash,omitempty"`
+	Datum     string          `json:"datum,omitempty"`
+	Script    json.RawMessage `json:"script,omitempty"`
 }

--- a/state_query.go
+++ b/state_query.go
@@ -63,16 +63,16 @@ func (c *Client) CurrentProtocolParameters(ctx context.Context) (json.RawMessage
 }
 
 func (c *Client) GenesisConfig(ctx context.Context, era string) (json.RawMessage, error) {
-       var (
-               payload = makePayload("queryNetwork/genesisConfiguration", Map{"era": era})
-               content struct{ Result json.RawMessage }
-       )
+	var (
+		payload = makePayload("queryNetwork/genesisConfiguration", Map{"era": era})
+		content struct{ Result json.RawMessage }
+	)
 
-       if err := c.query(ctx, payload, &content); err != nil {
-               return nil, err
-       }
+	if err := c.query(ctx, payload, &content); err != nil {
+		return nil, err
+	}
 
-       return content.Result, nil
+	return content.Result, nil
 }
 
 type EraHistory struct {
@@ -130,10 +130,10 @@ func (c *Client) EraStart(ctx context.Context) (statequery.EraStart, error) {
 	return content.Result, nil
 }
 
-func (c *Client) UtxosByAddress(ctx context.Context, addresses ...string) ([]statequery.Utxo, error) {
+func (c *Client) UtxosByAddress(ctx context.Context, addresses ...string) ([]statequery.UtxoData, error) {
 	var (
 		payload = makePayload("queryLedgerState/utxo", Map{"addresses": addresses})
-		content struct{ Result []statequery.Utxo }
+		content struct{ Result []statequery.UtxoData }
 	)
 
 	if err := c.query(ctx, payload, &content); err != nil {
@@ -143,10 +143,10 @@ func (c *Client) UtxosByAddress(ctx context.Context, addresses ...string) ([]sta
 	return content.Result, nil
 }
 
-func (c *Client) UtxosByTxIn(ctx context.Context, txIns ...chainsync.TxInQuery) ([]statequery.Utxo, error) {
+func (c *Client) UtxosByTxIn(ctx context.Context, txIns ...chainsync.TxInQuery) ([]statequery.UtxoData, error) {
 	var (
 		payload = makePayload("queryLedgerState/utxo", Map{"outputReferences": txIns})
-		content struct{ Result []statequery.Utxo }
+		content struct{ Result []statequery.UtxoData }
 	)
 
 	if err := c.query(ctx, payload, &content); err != nil {

--- a/state_query.go
+++ b/state_query.go
@@ -130,10 +130,10 @@ func (c *Client) EraStart(ctx context.Context) (statequery.EraStart, error) {
 	return content.Result, nil
 }
 
-func (c *Client) UtxosByAddress(ctx context.Context, addresses ...string) ([]statequery.UtxoData, error) {
+func (c *Client) UtxosByAddress(ctx context.Context, addresses ...string) ([]statequery.TxOut, error) {
 	var (
 		payload = makePayload("queryLedgerState/utxo", Map{"addresses": addresses})
-		content struct{ Result []statequery.UtxoData }
+		content struct{ Result []statequery.TxOut }
 	)
 
 	if err := c.query(ctx, payload, &content); err != nil {
@@ -143,10 +143,10 @@ func (c *Client) UtxosByAddress(ctx context.Context, addresses ...string) ([]sta
 	return content.Result, nil
 }
 
-func (c *Client) UtxosByTxIn(ctx context.Context, txIns ...chainsync.TxInQuery) ([]statequery.UtxoData, error) {
+func (c *Client) UtxosByTxIn(ctx context.Context, txIns ...chainsync.TxInQuery) ([]statequery.TxOut, error) {
 	var (
 		payload = makePayload("queryLedgerState/utxo", Map{"outputReferences": txIns})
-		content struct{ Result []statequery.UtxoData }
+		content struct{ Result []statequery.TxOut }
 	)
 
 	if err := c.query(ctx, payload, &content); err != nil {

--- a/state_query_test.go
+++ b/state_query_test.go
@@ -169,7 +169,7 @@ func TestClient_UtxosByTxIn(t *testing.T) {
 	ctx := context.Background()
 	client := New(WithEndpoint(endpoint), WithLogger(DefaultLogger))
 	utxos, err := client.UtxosByTxIn(ctx, chainsync.TxInQuery{
-		Transaction: chainsync.UtxoTxID{
+		Transaction: shared.UtxoTxID{
 			ID: "0000000000000000000000000000000000000000000000000000000000000000",
 		},
 		Index: 0,


### PR DESCRIPTION
- The Utxo type is accurate (state query response) but doesn't delineate what's related to TxIn and TxOut. Tweak the type to be more intuitive.
- ouroboros/chainsync and ouroboros/statequery both use their own identical UtxoTxID types. Move to a shared folder.