### PR TITLE
Various Ogmigo fixes & enhancements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Test chainsync v5",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/ouroboros/chainsync/v5/types_test.go",
+            "env": {},
+            "args": [],
+            "showLog": true
+        },
+        {
+            "name": "Test chainsync default",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/ouroboros/chainsync/types_test.go",
+            "env": {},
+            "args": [],
+            "showLog": true
+        },
+    ],
+}

--- a/ouroboros/chainsync/compatibility/types_test.go
+++ b/ouroboros/chainsync/compatibility/types_test.go
@@ -368,42 +368,35 @@ func TestDynamoDBMarshal(t *testing.T) {
 		assert.EqualValues(t, compatible, got.ConvertToV6())
 	})
 	// If we need a compatible Tx type, uncomment this test
-	/*
-	   t.Run("Tx v5", func(t *testing.T) {
-	      rawData, err := os.ReadFile("test_data/Tx_v5.json")
-	      assert.Nil(t, err)
+	t.Run("Tx v5", func(t *testing.T) {
+		rawData, err := os.ReadFile("test_data/Tx_v5.json")
+		assert.Nil(t, err)
 
-	      var compatible CompatibleTx
-	      err = json.Unmarshal(rawData, &compatible)
-	      assert.Nil(t, err)
+		var compatible CompatibleTx
+		err = json.Unmarshal(rawData, &compatible)
+		assert.Nil(t, err)
 
-	      av, err := dynamodbattribute.Marshal(&compatible)
-	      assert.Nil(t, err)
-	      assert.NotNil(t, av.M)
+		av, err := dynamodbattribute.Marshal(&compatible)
+		assert.Nil(t, err)
+		assert.NotNil(t, av.M)
 
-	      var got v5.TxV5
-	      err = dynamodbattribute.Unmarshal(av, &got)
-	      assert.Nil(t, err)
-	      assert.EqualValues(t, compatible, got.ConvertToV6())
-	   })
-	   t.Run("Tx v6", func(t *testing.T) {
-	      rawData, err := os.ReadFile("test_data/Tx_v6.json")
-	      assert.Nil(t, err)
+		var got v5.TxV5
+		err = dynamodbattribute.Unmarshal(av, &got)
+		assert.Nil(t, err)
+		assert.EqualValues(t, compatible, got.ConvertToV6())
+	})
+	t.Run("Tx v6", func(t *testing.T) {
+		rawData, err := os.ReadFile("test_data/Tx_v6.json")
+		assert.Nil(t, err)
 
-	      var compatible CompatibleTx
-	      err = json.Unmarshal(rawData, &compatible)
-	      assert.Nil(t, err)
+		var compatible CompatibleTx
+		err = json.Unmarshal(rawData, &compatible)
+		assert.Nil(t, err)
 
-	      av, err := dynamodbattribute.Marshal(&compatible)
-	      assert.Nil(t, err)
-	      assert.NotNil(t, av.M)
-
-	      var got v5.TxV5
-	      err = dynamodbattribute.Unmarshal(av, &got)
-	      assert.Nil(t, err)
-	      assert.EqualValues(t, compatible, got.ConvertToV6())
-	   })
-	*/
+		av, err := dynamodbattribute.Marshal(&compatible)
+		assert.Nil(t, err)
+		assert.NotNil(t, av.M)
+	})
 }
 
 func TestSerializeCompatibleValue(t *testing.T) {

--- a/ouroboros/chainsync/types.go
+++ b/ouroboros/chainsync/types.go
@@ -458,7 +458,7 @@ type Tx struct {
 	Fee                      Lovelace            `json:"fee,omitempty"                      dynamodbav:"fee,omitempty"`
 	ValidityInterval         ValidityInterval    `json:"validityInterval"                   dynamodbav:"validityInterval,omitempty"`
 	Mint                     shared.Value        `json:"mint,omitempty"                     dynamodbav:"mint,omitempty"`
-	Network                  *string             `json:"network,omitempty"                  dynamodbav:"network,omitempty"`
+	Network                  string              `json:"network,omitempty"                  dynamodbav:"network,omitempty"`
 	ScriptIntegrityHash      string              `json:"scriptIntegrityHash,omitempty"      dynamodbav:"scriptIntegrityHash,omitempty"`
 	RequiredExtraSignatories []string            `json:"requiredExtraSignatories,omitempty" dynamodbav:"requiredExtraSignatories,omitempty"`
 	RequiredExtraScripts     []string            `json:"requiredExtraScripts,omitempty"     dynamodbav:"requiredExtraScripts,omitempty"`

--- a/ouroboros/chainsync/v5/test_data/Tx_v6.json
+++ b/ouroboros/chainsync/v5/test_data/Tx_v6.json
@@ -125,7 +125,7 @@
     },
     "signatories": [
         {
-            "addressAttributes": "2F0=",
+            "addressAttributes": "2f",
             "chainCode": "12340000",
             "key": "d88f6028cc3d6d335115de3737bc2fe80a9a57a21a2c7c228ebc33b222e0897b",
             "signature": "feb447eca6b819f88b4b6aac81a97200121dd4451bfccb65f73d31de296b5402eead42848808633ad1d4afbfad3a2f1967ce65516adca5cd373673f758a9c096"

--- a/ouroboros/chainsync/v5/types_test.go
+++ b/ouroboros/chainsync/v5/types_test.go
@@ -28,15 +28,32 @@ func TestV5(t *testing.T) {
 		rawData, err := os.ReadFile("test_data/Tx_v6.json")
 		assert.Nil(t, err)
 
-		var expected chainsync.Tx
-		err = json.Unmarshal(rawData, &expected)
+		var expectedV6 chainsync.Tx
+		err = json.Unmarshal(rawData, &expectedV6)
 		assert.Nil(t, err)
-		actual := TxFromV6(expected)
+		v5Conversion := TxFromV6(expectedV6)
+		v6Conversion := v5Conversion.ConvertToV6()
 
-		// Signature: feb447eca6b819f88b4b6aac81a97200121dd4451bfccb65f73d31de296b5402eead42848808633ad1d4afbfad3a2f1967ce65516adca5cd373673f758a9c096
+		var bootstrapV5Sigs []chainsync.Signature
+		for _, x := range v5Conversion.Witness.Bootstrap {
+			var sig chainsync.Signature
+			json.Unmarshal(x, &sig)
+			bootstrapV5Sigs = append(bootstrapV5Sigs, sig)
+		}
+
+		network := "mainnet"
 		bootstrap := "{\"key\":\"d88f6028cc3d6d335115de3737bc2fe80a9a57a21a2c7c228ebc33b222e0897b\",\"signature\":\"/rRH7Ka4GfiLS2qsgalyABId1EUb/Mtl9z0x3ilrVALurUKEiAhjOtHUr7+tOi8ZZ85lUWrcpc03NnP3WKnAlg==\",\"chainCode\":\"12340000\",\"addressAttributes\":\"Lw==\"}"
-		assert.Equal(t, "feb447eca6b819f88b4b6aac81a97200121dd4451bfccb65f73d31de296b5402eead42848808633ad1d4afbfad3a2f1967ce65516adca5cd373673f758a9c096", expected.Signatories[0].Signature)
-		assert.Equal(t, bootstrap, string(actual.Witness.Bootstrap[0]))
-		assert.Equal(t, "IFb1lTq+ivhYQz6fAoPZQXuGgebeh5fIsM8rocK03mbss8yaUQpf871Qso2aAYaxjDadDHzMfUPRCJDpTyVxQg==", actual.Witness.Signatures["400019217786c3630fb121c455065b879055aa0ced5076a24abe8d6c837e0318"])
+		assert.Equal(t, "2f", expectedV6.Signatories[0].AddressAttributes)
+		assert.Equal(t, "12340000", expectedV6.Signatories[0].ChainCode)
+		assert.Equal(t, "d88f6028cc3d6d335115de3737bc2fe80a9a57a21a2c7c228ebc33b222e0897b", expectedV6.Signatories[0].Key)
+		assert.Equal(t, "feb447eca6b819f88b4b6aac81a97200121dd4451bfccb65f73d31de296b5402eead42848808633ad1d4afbfad3a2f1967ce65516adca5cd373673f758a9c096", expectedV6.Signatories[0].Signature)
+		assert.Equal(t, bootstrap, string(v5Conversion.Witness.Bootstrap[0]))
+		assert.Equal(t, "IFb1lTq+ivhYQz6fAoPZQXuGgebeh5fIsM8rocK03mbss8yaUQpf871Qso2aAYaxjDadDHzMfUPRCJDpTyVxQg==", v5Conversion.Witness.Signatures["400019217786c3630fb121c455065b879055aa0ced5076a24abe8d6c837e0318"])
+		assert.Equal(t, json.RawMessage(network), v5Conversion.Body.Network)
+		assert.Equal(t, network, v6Conversion.Network)
+		assert.Equal(t, expectedV6.Signatories[0].AddressAttributes, v6Conversion.Signatories[2].AddressAttributes)
+		assert.Equal(t, expectedV6.Signatories[0].ChainCode, v6Conversion.Signatories[2].ChainCode)
+		assert.Equal(t, expectedV6.Signatories[0].Key, v6Conversion.Signatories[2].Key)
+		assert.Equal(t, expectedV6.Signatories[0].Signature, v6Conversion.Signatories[2].Signature)
 	})
 }


### PR DESCRIPTION
- Add CompatibleTx and enable related tests.
- *string -> json.RawMessage for Tx type, aligning with what was in v5.
- Alignment with the fact that v5->v6 Tx conversion is "lossy" by nature.
- Fix incorrect unit test data. ("addressAttributes" in v6 should be a hex string, not Base64.)
- Add VS Code file making it easier to conduct debugging operations.