### PR TITLE
Update ogmigo to support the final Ogmios v6 release.

### DIFF
--- a/ouroboros/chainsync/compatibility/test_data/Response_NextBlock_v6.json
+++ b/ouroboros/chainsync/compatibility/test_data/Response_NextBlock_v6.json
@@ -75,25 +75,29 @@
                         {
                             "type": "genesisDelegation",
                             "delegate": {
-                                "id": "494fa3cd83702be91b29d667a877e1eccddbbe4d0e9422ae2459fad0"
+                                "id": "494fa3cd83702be91b29d667a877e1eccddbbe4d0e9422ae2459fad0",
+                                "vrfVerificationKeyHash": "ca29e3a74ac74fec0bcd8954ead4acb449ffa2c2ac8a60a4d3e1931ab6ec1b2e"
                             },
                             "issuer": {
-                                "id": "46f68923ce0ef874eec18fbd642014f710f518007cb3d3fb8b13ded0",
-                                "vrfVerificationKeyHash": "ca29e3a74ac74fec0bcd8954ead4acb449ffa2c2ac8a60a4d3e1931ab6ec1b2e"
+                                "id": "46f68923ce0ef874eec18fbd642014f710f518007cb3d3fb8b13ded0"
                             }
                         }
                     ],
                     "withdrawals": {
                         "stake_test1urrqy7dtj3n5snr2nzhat0y3nh7fx7hj45cpzjv42lg5e2sdserua": {
-                            "lovelace": 356934
+                            "ada": {
+                                "lovelace": 356934
+                            }
                         },
                         "stake1u9zpdf4gvr253sut07mh6p09wa8j5rpqjzw92tezfd3y98qk2x86v": {
-                            "lovelace": 578832
+                            "ada": {
+                                "lovelace": 578832
+                            }
                         }
                     },
                     "mint": {
                         "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                            "61f07e5713ceb5d6d03b0170d595cc2b717057bef71c8f3fc4b82212a44b": 3162197447987995600
+                            "61f07e5713ceb5d6d03b0170d595cc2b717057bef71c8f3fc4b82212a44b": 3162197447987995651
                         }
                     },
                     "requiredExtraSignatories": [
@@ -101,7 +105,9 @@
                     ],
                     "scriptIntegrityHash": "93493ff6e5c49f80426804076e428e99db2360104c898c232af8b11234a9efdc",
                     "fee": {
-                        "lovelace": 973423
+                        "ada": {
+                            "lovelace": 973423
+                        }
                     },
                     "validityInterval": {
                         "invalidBefore": 3
@@ -136,25 +142,33 @@
                         "0336e5811d0e397ede4de304aaef9f50a4f21fef70442d0a86026ed89565ad0b": "a4d87c9fd87c9f2005202000ffff009f9f42f65a432a9e8bffff9f4158d87c9f0442367a042002ffd87a9f443251f1deffff9fa0d87e9f4373928fffff9f242224a342a7e82220435cd2f80340ff2003",
                         "76279ac9b71237227d154ecee4ac914b270e0e260e66ed9df4ff84da1e84e2d3": "9fa2a20043c8ddd020414020d87b9f0141d1418eff9f426d45ff4123ff"
                     },
-                    "redeemers": {
-                        "certificate:2": {
+                    "redeemers": [
+                        {
+                            "validator": {
+                                "index": 2,
+                                "purpose": "publish"
+                            },
                             "redeemer": "a0",
                             "executionUnits": {
-                                "memory": 8826057976430752000,
-                                "cpu": 4708641250314348000
+                                "memory": 8826057976430751388,
+                                "cpu": 4708641250314347743
                             }
                         },
-                        "certificate:3": {
+                        {
+                            "validator": {
+                                "index": 3,
+                                "purpose": "publish"
+                            },
                             "redeemer": "9fd87d9fd8799f200241e0ffd87e9f41d9426046412d22ff2243a3744303ffa29f04447a1666eb44baef15a701ff434e989f20d8799f40442b68d71241ccffd87d9f416a219f042443ac6641ffffff",
                             "executionUnits": {
-                                "memory": 3376484474234959400,
-                                "cpu": 3703451964476255700
+                                "memory": 3376484474234959459,
+                                "cpu": 3703451964476255843
                             }
                         }
-                    }
+                    ]
                 },
                 {
-                    "id": "db82d91485a628e3732f881c79199c01ece029398329121231296e5c4ca827c6",
+                    "id": "58924fded958dda8a7ac6a120f00eea7e7374ff8ce54751e4ce9db689604b90c",
                     "spends": "collaterals",
                     "inputs": [
                         {
@@ -175,10 +189,10 @@
                             "address": "addr1gx2fe5rhglqrcgf2cpn0fyuvh2cy97ax0lz3v70qv2jmgkczqqqs0pwy02",
                             "value": {
                                 "ada": {
-                                    "lovelace": 312617921725660100
+                                    "lovelace": 5471871707173873214
                                 },
                                 "709fc5abc5df4cfee75360cfa9f3ee7d36d6cb216a0ba4daddb16366": {
-                                    "35": 3812892794721600000
+                                    "35": 1
                                 }
                             },
                             "datumHash": "3c7a5f2e2f52c4756b9b359b63b316c77e9113f635c8690bb1b506b7c9b890f2"
@@ -187,10 +201,10 @@
                             "address": "addr_test1qr0y0q76tdu63exxxfhrcq00u3vpz3jfe0dnevcy5e6tlx23r7kvyuvvj8njqwhrrsv4jsw73uv0apx966rksaa66hzqpu75h5",
                             "value": {
                                 "ada": {
-                                    "lovelace": 3531149964235084000
+                                    "lovelace": 2359388962328459812
                                 },
                                 "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                    "f3fae0095e78ccade17ffa547dd9cd839ebe65": 2153730649591039000
+                                    "f3fae0095e78ccade17ffa547dd9cd839ebe65": 1
                                 }
                             },
                             "datumHash": "4ad8cd5be6986e6c3eb4d3f942c75e68a8e0be40e405c240781964698fca137c"
@@ -199,10 +213,10 @@
                             "address": "addr1q8qgshfmdt5vkx2msf48qtvg3pgurrgxau482m2yyw0c2483lhxjm7kxtt28lhsfkd9mlwtlj3z92nm7zs3m30w7h4hqarsdu2",
                             "value": {
                                 "ada": {
-                                    "lovelace": 4968142171704102000
+                                    "lovelace": 6998929950975338793
                                 },
                                 "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                    "34": 7989804813950565000
+                                    "34": 1
                                 }
                             },
                             "datumHash": "0f768d10304e2488f0cf50cd5c8ac25133291b4bf36db311e7ec19bd7ef9eb65"
@@ -219,25 +233,29 @@
                         {
                             "type": "genesisDelegation",
                             "delegate": {
-                                "id": "fdefd8e3beb32cd86c84959f8e156a32a1ba3876ebdd868ad3eefb7c"
+                                "id": "fdefd8e3beb32cd86c84959f8e156a32a1ba3876ebdd868ad3eefb7c",
+                                "vrfVerificationKeyHash": "15f1292a444fe5aa73f95d9d75e4a1909d6aa05fca22a21174a330232ef41a29"
                             },
                             "issuer": {
-                                "id": "50699ad21903e2cc251fdccb6641b78df70fb5972862a4597a1cb6b4",
-                                "vrfVerificationKeyHash": "15f1292a444fe5aa73f95d9d75e4a1909d6aa05fca22a21174a330232ef41a29"
+                                "id": "50699ad21903e2cc251fdccb6641b78df70fb5972862a4597a1cb6b4"
                             }
                         }
                     ],
                     "withdrawals": {
                         "stake_test17qrerkduc7v5vt5mfz4j3vhv667q9lxv4aldhqq6v7cml0gwacue2": {
-                            "lovelace": 433263
+                            "ada": {
+                                "lovelace": 433263
+                            }
                         },
                         "stake178cxrn5h9fqftntssdrjh0kwd6622vlqu3h8r7tl8gnzrhsnvljkg": {
-                            "lovelace": 224375
+                            "ada": {
+                                "lovelace": 224375
+                            }
                         }
                     },
                     "mint": {
                         "39c7e3a4c1dc6032dc0ea4d471195037c85ed90b31926954cd5446c6": {
-                            "1e7a8d28bb1c1988ff842ff101e2e5": 3697388719172431000
+                            "1e7a8d28bb1c1988ff842ff101e2e5": 3697388719172430741
                         }
                     },
                     "requiredExtraSignatories": [
@@ -252,7 +270,9 @@
                     "network": "mainnet",
                     "scriptIntegrityHash": "89fc262c4561ccabd5cfb8a9e30ba3c928b2910829b86096ba771ca387aa1d49",
                     "fee": {
-                        "lovelace": 464857
+                        "ada": {
+                            "lovelace": 464857
+                        }
                     },
                     "validityInterval": {
                         "invalidBefore": 4,
@@ -265,7 +285,9 @@
                                 "source": "treasury",
                                 "target": "reserves",
                                 "value": {
-                                    "lovelace": 142671
+                                    "ada": {
+                                        "lovelace": 142671
+                                    }
                                 }
                             }
                         }

--- a/ouroboros/chainsync/compatibility/test_data/RollForward_v6.json
+++ b/ouroboros/chainsync/compatibility/test_data/RollForward_v6.json
@@ -10,7 +10,7 @@
             "proof": "98fbb316e8bbd717ca27325d44eaaf90867b8351a7b9839a1b19e8e6b416791363470f0709ba78f6a5c4f50dee2e6295aa04a4fd125143b0dfdbed7422b6efe49ad4b94c34eb7f434c486e1d803e0b0a"
         },
         "height": 0,
-        "slot": 2,
+        "slot": 0,
         "issuer": {
             "verificationKey": "948b49ced8f0316e7d33a8de788eb3ba3ea88deb2716bf185cae5820591fdabf",
             "vrfVerificationKey": "224655a70fb7d8cb8f900c97f16cfc45645124a1d388b6eaa2c4511ef5da79d8",
@@ -19,7 +19,7 @@
                 "proof": "a2876927ad069b694d87cf070e49f7786ba1312b25dcc501657b545a1297fe0db1627d96d6a3ca7bbf4e8ede19885e4a164bd8d4e31d747fcd05ac63f17af4a58503a6417ce9554724f30b7dada17f05"
             },
             "operationalCertificate": {
-                "count": 0,
+                "count": 4,
                 "kes": {
                     "period": 2,
                     "verificationKey": "b39372534cb0636dfdfcab8e7726aa7bb3160ef9b640a52bb0a043093baa613d"
@@ -37,14 +37,14 @@
         },
         "transactions": [
             {
-                "id": "2bd3c9bb48d587f9a6bccb8230110ba0c536aa05c5966b1a63052b26775db4f4",
+                "id": "3413d974c45856182c284bdc9bf10291a97cdc6dbe5f4a56cf9b8e7ffff32d68",
                 "spends": "inputs",
                 "inputs": [
                     {
                         "transaction": {
                             "id": "7525e434d3b951d3499b87f8cbd02ed0ebb0c0248343af568c29d15e79825bd8"
                         },
-                        "index": 0
+                        "index": 3
                     }
                 ],
                 "outputs": [
@@ -67,14 +67,18 @@
                 ],
                 "withdrawals": {
                     "stake_test17re7uuh9zercugh782esdhp4lspnz6k7sspk7254yagzpwq83d45f": {
-                        "lovelace": 37534
+                        "ada": {
+                            "lovelace": 37534
+                        }
                     }
                 },
                 "fee": {
-                    "lovelace": 737494
+                    "ada": {
+                        "lovelace": 737494
+                    }
                 },
                 "validityInterval": {
-                    "invalidBefore": 1,
+                    "invalidBefore": 2,
                     "invalidAfter": 1
                 },
                 "signatories": [

--- a/ouroboros/chainsync/compatibility/test_data/Tx_v6.json
+++ b/ouroboros/chainsync/compatibility/test_data/Tx_v6.json
@@ -1,5 +1,5 @@
 {
-    "id": "db82d91485a628e3732f881c79199c01ece029398329121231296e5c4ca827c6",
+    "id": "58924fded958dda8a7ac6a120f00eea7e7374ff8ce54751e4ce9db689604b90c",
     "spends": "collaterals",
     "inputs": [
         {
@@ -20,10 +20,10 @@
             "address": "addr1gx2fe5rhglqrcgf2cpn0fyuvh2cy97ax0lz3v70qv2jmgkczqqqs0pwy02",
             "value": {
                 "ada": {
-                    "lovelace": 312617921725660100
+                    "lovelace": 5471871707173873214
                 },
                 "709fc5abc5df4cfee75360cfa9f3ee7d36d6cb216a0ba4daddb16366": {
-                    "35": 3812892794721600000
+                    "35": 1
                 }
             },
             "datumHash": "3c7a5f2e2f52c4756b9b359b63b316c77e9113f635c8690bb1b506b7c9b890f2"
@@ -32,10 +32,10 @@
             "address": "addr_test1qr0y0q76tdu63exxxfhrcq00u3vpz3jfe0dnevcy5e6tlx23r7kvyuvvj8njqwhrrsv4jsw73uv0apx966rksaa66hzqpu75h5",
             "value": {
                 "ada": {
-                    "lovelace": 3531149964235084000
+                    "lovelace": 2359388962328459812
                 },
                 "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                    "f3fae0095e78ccade17ffa547dd9cd839ebe65": 2153730649591039000
+                    "f3fae0095e78ccade17ffa547dd9cd839ebe65": 1
                 }
             },
             "datumHash": "4ad8cd5be6986e6c3eb4d3f942c75e68a8e0be40e405c240781964698fca137c"
@@ -44,10 +44,10 @@
             "address": "addr1q8qgshfmdt5vkx2msf48qtvg3pgurrgxau482m2yyw0c2483lhxjm7kxtt28lhsfkd9mlwtlj3z92nm7zs3m30w7h4hqarsdu2",
             "value": {
                 "ada": {
-                    "lovelace": 4968142171704102000
+                    "lovelace": 6998929950975338793
                 },
                 "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                    "34": 7989804813950565000
+                    "34": 1
                 }
             },
             "datumHash": "0f768d10304e2488f0cf50cd5c8ac25133291b4bf36db311e7ec19bd7ef9eb65"
@@ -64,25 +64,29 @@
         {
             "type": "genesisDelegation",
             "delegate": {
-                "id": "fdefd8e3beb32cd86c84959f8e156a32a1ba3876ebdd868ad3eefb7c"
+                "id": "fdefd8e3beb32cd86c84959f8e156a32a1ba3876ebdd868ad3eefb7c",
+                "vrfVerificationKeyHash": "15f1292a444fe5aa73f95d9d75e4a1909d6aa05fca22a21174a330232ef41a29"
             },
             "issuer": {
-                "id": "50699ad21903e2cc251fdccb6641b78df70fb5972862a4597a1cb6b4",
-                "vrfVerificationKeyHash": "15f1292a444fe5aa73f95d9d75e4a1909d6aa05fca22a21174a330232ef41a29"
+                "id": "50699ad21903e2cc251fdccb6641b78df70fb5972862a4597a1cb6b4"
             }
         }
     ],
     "withdrawals": {
         "stake_test17qrerkduc7v5vt5mfz4j3vhv667q9lxv4aldhqq6v7cml0gwacue2": {
-            "lovelace": 433263
+            "ada": {
+                "lovelace": 433263
+            }
         },
         "stake178cxrn5h9fqftntssdrjh0kwd6622vlqu3h8r7tl8gnzrhsnvljkg": {
-            "lovelace": 224375
+            "ada": {
+                "lovelace": 224375
+            }
         }
     },
     "mint": {
         "39c7e3a4c1dc6032dc0ea4d471195037c85ed90b31926954cd5446c6": {
-            "1e7a8d28bb1c1988ff842ff101e2e5": 3697388719172431000
+            "1e7a8d28bb1c1988ff842ff101e2e5": 3697388719172430741
         }
     },
     "requiredExtraSignatories": [
@@ -97,7 +101,9 @@
     "network": "mainnet",
     "scriptIntegrityHash": "89fc262c4561ccabd5cfb8a9e30ba3c928b2910829b86096ba771ca387aa1d49",
     "fee": {
-        "lovelace": 464857
+        "ada": {
+            "lovelace": 464857
+        }
     },
     "validityInterval": {
         "invalidBefore": 4,
@@ -110,7 +116,9 @@
                 "source": "treasury",
                 "target": "reserves",
                 "value": {
-                    "lovelace": 142671
+                    "ada": {
+                        "lovelace": 142671
+                    }
                 }
             }
         }

--- a/ouroboros/chainsync/compatibility/types.go
+++ b/ouroboros/chainsync/compatibility/types.go
@@ -273,7 +273,7 @@ func (c *CompatibleValue) UnmarshalJSON(data []byte) error {
 
 	s := shared.Value{}
 	if r5.Coins.BigInt().BitLen() != 0 {
-		s.AddAsset(shared.Coin{AssetId: shared.AdaAssetID, Amount: r5.Coins})
+		s.AddAsset(shared.CreateAdaCoin(r5.Coins))
 	}
 	for asset, coins := range r5.Assets {
 		s.AddAsset(shared.Coin{AssetId: asset, Amount: coins})

--- a/ouroboros/chainsync/compatibility/types_test.go
+++ b/ouroboros/chainsync/compatibility/types_test.go
@@ -309,7 +309,7 @@ func TestCompatibleResponse(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("Full Response Roll Forward V5", func(t *testing.T) {
+	t.Run("Full Response Roll Forward V6", func(t *testing.T) {
 		rawData, err := os.ReadFile("test_data/Response_NextBlock_v6.json")
 		assert.Nil(t, err)
 
@@ -451,11 +451,11 @@ func TestSerializeCompatibleValue(t *testing.T) {
 func Test_ValueChecks(t *testing.T) {
 	t.Run("string", func(t *testing.T) {
 		equal1 := shared.ValueFromCoins(
-			shared.Coin{AssetId: shared.AdaAssetID, Amount: num.Int64(1000000)},
+			shared.CreateAdaCoin(num.Int64(1000000)),
 			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
 		)
 		equal2 := shared.ValueFromCoins(
-			shared.Coin{AssetId: shared.AdaAssetID, Amount: num.Int64(1000000)},
+			shared.CreateAdaCoin(num.Int64(1000000)),
 			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
 		)
 		if !shared.Equal(equal1, equal2) {
@@ -463,19 +463,19 @@ func Test_ValueChecks(t *testing.T) {
 		}
 
 		val1 := shared.ValueFromCoins(
-			shared.Coin{AssetId: shared.AdaAssetID, Amount: num.Int64(1000001)},
+			shared.CreateAdaCoin(num.Int64(1000001)),
 			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
 		)
 		val2 := shared.ValueFromCoins(
-			shared.Coin{AssetId: shared.AdaAssetID, Amount: num.Int64(1000000)},
+			shared.CreateAdaCoin(num.Int64(1000000)),
 			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
 		)
 		val3 := shared.ValueFromCoins(
-			shared.Coin{AssetId: shared.AdaAssetID, Amount: num.Int64(1000000)},
+			shared.CreateAdaCoin(num.Int64(1000000)),
 			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(12345678900)},
 		)
 		val4 := shared.ValueFromCoins(
-			shared.Coin{AssetId: shared.AdaAssetID, Amount: num.Int64(1000000)},
+			shared.CreateAdaCoin(num.Int64(1000000)),
 			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
 		)
 		if !shared.GreaterThanOrEqual(val1, val2) {
@@ -491,7 +491,7 @@ func Test_ValueChecks(t *testing.T) {
 			t.Fatalf("%v is not less than %v", val4, val3)
 		}
 		if ok, err := shared.Enough(val3, val4); !ok {
-			t.Fatalf("%v does not have enough assets for %v: %v", val4, val3, err)
+			t.Fatalf("%v does not have enough assets for %v: %v", val4, val3, err.Error())
 		}
 		if shared.Equal(val1, val2) {
 			t.Fatalf("%v and %v are equal", val1, val2)
@@ -502,7 +502,7 @@ func Test_ValueChecks(t *testing.T) {
 
 		val5 := shared.Add(val1, val2)
 		val6 := shared.ValueFromCoins(
-			shared.Coin{AssetId: shared.AdaAssetID, Amount: num.Int64(2000001)},
+			shared.CreateAdaCoin(num.Int64(2000001)),
 			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(2469135780)},
 		)
 		if !shared.Equal(val5, val6) {
@@ -510,12 +510,12 @@ func Test_ValueChecks(t *testing.T) {
 		}
 
 		val7 := shared.ValueFromCoins(
-			shared.Coin{AssetId: shared.AdaAssetID, Amount: num.Int64(600000)},
+			shared.CreateAdaCoin(num.Int64(600000)),
 			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(2345678900)},
 		)
 		val8 := shared.Subtract(val3, val7)
 		val9 := shared.ValueFromCoins(
-			shared.Coin{AssetId: shared.AdaAssetID, Amount: num.Int64(400000)},
+			shared.CreateAdaCoin(num.Int64(400000)),
 			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(10000000000)},
 		)
 		if !shared.Equal(val8, val9) {

--- a/ouroboros/chainsync/types.go
+++ b/ouroboros/chainsync/types.go
@@ -28,13 +28,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/fxamacker/cbor/v2"
 
-	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync/num"
 	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/shared"
 )
 
 var (
-	encOptions = cbor.CoreDetEncOptions()
-	bNil       = []byte("nil")
+	bNil = []byte("nil")
 )
 
 // All blocks except Byron-era blocks.
@@ -445,37 +443,31 @@ type Signature struct {
 }
 
 type Tx struct {
-	ID                       string              `json:"id,omitempty"                       dynamodbav:"id,omitempty"`
-	Spends                   string              `json:"spends,omitempty"                   dynamodbav:"spends,omitempty"`
-	Inputs                   []TxIn              `json:"inputs,omitempty"                   dynamodbav:"inputs,omitempty"`
-	References               []TxIn              `json:"references,omitempty"               dynamodbav:"references,omitempty"`
-	Collaterals              []TxIn              `json:"collaterals,omitempty"              dynamodbav:"collaterals,omitempty"`
-	TotalCollateral          *Lovelace           `json:"totalCollateral,omitempty"          dynamodbav:"totalCollateral,omitempty"`
-	CollateralReturn         *TxOut              `json:"collateralReturn,omitempty"         dynamodbav:"collateralReturn,omitempty"`
-	Outputs                  TxOuts              `json:"outputs,omitempty"                  dynamodbav:"outputs,omitempty"`
-	Certificates             []json.RawMessage   `json:"certificates,omitempty"             dynamodbav:"certificates,omitempty"`
-	Withdrawals              map[string]Lovelace `json:"withdrawals,omitempty"              dynamodbav:"withdrawals,omitempty"`
-	Fee                      Lovelace            `json:"fee,omitempty"                      dynamodbav:"fee,omitempty"`
-	ValidityInterval         ValidityInterval    `json:"validityInterval"                   dynamodbav:"validityInterval,omitempty"`
-	Mint                     shared.Value        `json:"mint,omitempty"                     dynamodbav:"mint,omitempty"`
-	Network                  string              `json:"network,omitempty"                  dynamodbav:"network,omitempty"`
-	ScriptIntegrityHash      string              `json:"scriptIntegrityHash,omitempty"      dynamodbav:"scriptIntegrityHash,omitempty"`
-	RequiredExtraSignatories []string            `json:"requiredExtraSignatories,omitempty" dynamodbav:"requiredExtraSignatories,omitempty"`
-	RequiredExtraScripts     []string            `json:"requiredExtraScripts,omitempty"     dynamodbav:"requiredExtraScripts,omitempty"`
-	Proposals                json.RawMessage     `json:"proposals,omitempty"                dynamodbav:"proposals,omitempty"`
-	Votes                    json.RawMessage     `json:"votes,omitempty"                    dynamodbav:"votes,omitempty"`
-	Metadata                 json.RawMessage     `json:"metadata,omitempty"                 dynamodbav:"metadata,omitempty"`
-	Signatories              []Signature         `json:"signatories,omitempty"              dynamodbav:"signatories,omitempty"`
-	Scripts                  json.RawMessage     `json:"scripts,omitempty"                  dynamodbav:"scripts,omitempty"`
-	Datums                   Datums              `json:"datums"                   dynamodbav:"datums,omitempty"`
-	Redeemers                json.RawMessage     `json:"redeemers,omitempty"                dynamodbav:"redeemers,omitempty"`
-	CBOR                     string              `json:"cbor,omitempty"                     dynamodbav:"cbor,omitempty"`
-}
-
-type DoubleNestedInteger map[string]map[string]num.Int
-
-type Lovelace struct {
-	Lovelace num.Int `json:"lovelace,omitempty"  dynamodbav:"lovelace,omitempty"`
+	ID                       string                  `json:"id,omitempty"                       dynamodbav:"id,omitempty"`
+	Spends                   string                  `json:"spends,omitempty"                   dynamodbav:"spends,omitempty"`
+	Inputs                   []TxIn                  `json:"inputs,omitempty"                   dynamodbav:"inputs,omitempty"`
+	References               []TxIn                  `json:"references,omitempty"               dynamodbav:"references,omitempty"`
+	Collaterals              []TxIn                  `json:"collaterals,omitempty"              dynamodbav:"collaterals,omitempty"`
+	TotalCollateral          *shared.Value           `json:"totalCollateral,omitempty"          dynamodbav:"totalCollateral,omitempty"`
+	CollateralReturn         *TxOut                  `json:"collateralReturn,omitempty"         dynamodbav:"collateralReturn,omitempty"`
+	Outputs                  TxOuts                  `json:"outputs,omitempty"                  dynamodbav:"outputs,omitempty"`
+	Certificates             []json.RawMessage       `json:"certificates,omitempty"             dynamodbav:"certificates,omitempty"`
+	Withdrawals              map[string]shared.Value `json:"withdrawals,omitempty"              dynamodbav:"withdrawals,omitempty"`
+	Fee                      shared.Value            `json:"fee,omitempty"                      dynamodbav:"fee,omitempty"`
+	ValidityInterval         ValidityInterval        `json:"validityInterval"                   dynamodbav:"validityInterval,omitempty"`
+	Mint                     shared.Value            `json:"mint,omitempty"                     dynamodbav:"mint,omitempty"`
+	Network                  string                  `json:"network,omitempty"                  dynamodbav:"network,omitempty"`
+	ScriptIntegrityHash      string                  `json:"scriptIntegrityHash,omitempty"      dynamodbav:"scriptIntegrityHash,omitempty"`
+	RequiredExtraSignatories []string                `json:"requiredExtraSignatories,omitempty" dynamodbav:"requiredExtraSignatories,omitempty"`
+	RequiredExtraScripts     []string                `json:"requiredExtraScripts,omitempty"     dynamodbav:"requiredExtraScripts,omitempty"`
+	Proposals                json.RawMessage         `json:"proposals,omitempty"                dynamodbav:"proposals,omitempty"`
+	Votes                    json.RawMessage         `json:"votes,omitempty"                    dynamodbav:"votes,omitempty"`
+	Metadata                 json.RawMessage         `json:"metadata,omitempty"                 dynamodbav:"metadata,omitempty"`
+	Signatories              []Signature             `json:"signatories,omitempty"              dynamodbav:"signatories,omitempty"`
+	Scripts                  json.RawMessage         `json:"scripts,omitempty"                  dynamodbav:"scripts,omitempty"`
+	Datums                   Datums                  `json:"datums"                             dynamodbav:"datums,omitempty"`
+	Redeemers                json.RawMessage         `json:"redeemers,omitempty"                dynamodbav:"redeemers,omitempty"`
+	CBOR                     string                  `json:"cbor,omitempty"                     dynamodbav:"cbor,omitempty"`
 }
 
 type TxID string

--- a/ouroboros/chainsync/types_test.go
+++ b/ouroboros/chainsync/types_test.go
@@ -373,7 +373,7 @@ func TestPraosResponse(t *testing.T) {
 				},
 				"transactions": [
 					{
-						"id": "c10ba8d6ba64a43067b6ccae8e20105cbb7e0dab45c16e8b4b2490c7f2575dbf",
+						"id": "9cd28711da282cb87cb9252e123f48c7b069619fc5f9d5bddeac0b11bbcf9d31",
 						"spends": "collaterals",
 						"inputs": [
 							{
@@ -420,10 +420,10 @@ func TestPraosResponse(t *testing.T) {
 								"address": "addr_test1xz8kaamzwgl7qeqezvk28jc7xwqt96lymetwhpfpltlc9fyx5z9682dlu90yaaz8lygzge8tt0jnpwfsp7hj0vydp9tq7jw5p3",
 								"value": {
 									"ada": {
-										"lovelace": 2734681338072915340
+										"lovelace": 6599517526229999871
 									},
 									"4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-										"a57b": 3969779072528401418
+										"a57b": 1
 									}
 								},
 								"datum": "43e33bf3",
@@ -466,10 +466,10 @@ func TestPraosResponse(t *testing.T) {
 							"address": "addr1y84cdp4x2n26uvlfe4txmnh0d37aunsf8evrlmwurpspw8zfh9mnrddv54u9lq8qpy09qcpupu2fnks5nwpknrm7vjps2vpr04",
 							"value": {
 								"ada": {
-									"lovelace": 5724148192744198172
+									"lovelace": 0
 								},
 								"2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
-									"35ab47a811413c": 2971153819476395723
+									"35ab47a811413c": 4946671062515366198
 								}
 							},
 							"datumHash": "c96ef3b6d4f5f5e1011391687a0c30bd5902342a257c945027af5524736e3996",
@@ -488,7 +488,9 @@ func TestPraosResponse(t *testing.T) {
 							}
 						},
 						"totalCollateral": {
-							"lovelace": 927637
+							"ada": {
+								"lovelace": 927637
+							}
 						},
 						"mint": {
 							"be8dc1ca8b6b1735175a24b3b3c39d7327aba843c16a9b99924f3476": {
@@ -497,7 +499,9 @@ func TestPraosResponse(t *testing.T) {
 						},
 						"network": "mainnet",
 						"fee": {
-							"lovelace": 752644
+							"ada": {
+								"lovelace": 752644
+							}
 						},
 						"validityInterval": {
 							"invalidBefore": 7,
@@ -509,13 +513,19 @@ func TestPraosResponse(t *testing.T) {
 									"type": "treasuryWithdrawals",
 									"withdrawals": {
 										"64519ff082ace5007781306a885bf04a6dfc6df57fe486d3d98b7cb5": {
-											"lovelace": -659851
+											"ada": {
+												"lovelace": -659851
+											}
 										},
 										"7e0531fb0ec714b6080d437377c91a56d3c4351e32ca2b27dd1f0195": {
-											"lovelace": 168719
+											"ada": {
+												"lovelace": 168719
+											}
 										},
 										"9c444af5980051bfc60ef4a54068cae4ba543461c8bd37b0c174c9b7": {
-											"lovelace": -562643
+											"ada": {
+												"lovelace": -562643
+											}
 										}
 									}
 								}
@@ -546,32 +556,44 @@ func TestPraosResponse(t *testing.T) {
 						"datums": {
 							"2208e439244a1d0ef238352e3693098aba9de9dd0154f9056551636c8ed15dc1": "23"
 						},
-						"redeemers": {
-							"spend:4": {
+						"redeemers": [
+							{
+								"validator": {
+									"index": 4,
+									"purpose": "spend"
+								},
 								"redeemer": "a5239fd87d9f004023014273aeff9f00418b2143ee26a901ffffa1d87d9f43bafcf405ff425ccc029fd87c9f40ff446e943aa9d87e9f4375079e4318997905054197ffff23a3d87d9f43ca6d3e044233884206eb20ff0505a2024022019f43570e4322402324ff9f423456ff01d87c9fd87e9f01ff9f01ffff00",
 								"executionUnits": {
 									"memory": 5528516116957021378,
 									"cpu": 3267967087510563235
 								}
 							},
-							"mint:2": {
+							{
+								"validator": {
+									"index": 2,
+									"purpose": "mint"
+								},
 								"redeemer": "d87b9f219f232041de009f44d47dc270ffffa3d87a9f0521ffa2024127054404aa1521d87980a24040444097f3a504d87d9f425ca843eb4ac704445f938c0905ff9f03ffa021ff",
 								"executionUnits": {
 									"memory": 5484661661513700435,
 									"cpu": 3616344145952188136
 								}
 							},
-							"withdrawal:2": {
+							{
+								"validator": {
+									"index": 2,
+									"purpose": "withdraw"
+								},
 								"redeemer": "d87c9f9f80a12442533fffa1d87d9f0201ffd8799f01ffff",
 								"executionUnits": {
 									"memory": 2494865883185442907,
 									"cpu": 4035456766489310695
 								}
 							}
-						}
+						]
 					},
 					{
-						"id": "b12bdf08cfb6140102b9d6105f982da6ff91943ae445bf052c92234728958b92",
+						"id": "8dbba7a7bc4314310a39570be19390cdbb97c587aecd7ab9bfcb02d67ae68e90",
 						"spends": "inputs",
 						"inputs": [],
 						"references": [
@@ -605,10 +627,10 @@ func TestPraosResponse(t *testing.T) {
 								"address": "addr_test1xqzw54uwqf90cd4ujrnk4ll2xqp23ud5z8uf0ux8jdvrela8ntznpfc7svwwr0ak5jj3j060dw09nvtrhnr4l803puyscse43f",
 								"value": {
 									"ada": {
-										"lovelace": 1771848557320187307
+										"lovelace": 1570446258331790065
 									},
 									"d2a51a7e7678a02de266788af63481ebaa437626cc87b8bf85d25f25": {
-										"36": 6334119551650706257
+										"36": 1
 									}
 								},
 								"datumHash": "8c19ef57d6180c563bd5f54f354aebc865fb07ca98b2cb4c62e1983575bba82f",
@@ -667,10 +689,10 @@ func TestPraosResponse(t *testing.T) {
 								"address": "addr1q9j6nk52759cv5dxxftfe4f2e3xqj0c4l7de0q5s6ecjqxdgxqe77rzpgudpjhjxms864zgxzmn4n4mqf60tdypqs8qssnn3cd",
 								"value": {
 									"ada": {
-										"lovelace": 14122285556284450
+										"lovelace": 0
 									},
 									"2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
-										"36d0f791518dfc7bdaa008ac496a96aa51258194ff9dfe52482d0ded489884": 672336696701854863
+										"36d0f791518dfc7bdaa008ac496a96aa51258194ff9dfe52482d0ded489884": 2
 									}
 								},
 								"datumHash": "e60700a4bdc5696f3b9162bb5bd6ca0bd0ed3d94a34e63d1ccaff374929efce6"
@@ -679,10 +701,10 @@ func TestPraosResponse(t *testing.T) {
 								"address": "addr_test1yrq9ayusqmlj862fzupd0euqrgugmv3punx9ya6fhfmkuju898c4uwkye65pt7tya9l43z3hevhadu5dj46gddfpa8hq6mzgtd",
 								"value": {
 									"ada": {
-										"lovelace": 913241529029639917
+										"lovelace": 0
 									},
 									"2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-										"504f4bba25991217": 8142521844435523815
+										"504f4bba25991217": 3183844862761547728
 									}
 								},
 								"datumHash": "0519e3b4094e19f636e21e8363561511f79f4522f45c4407798265e8814ea4e6",
@@ -726,17 +748,19 @@ func TestPraosResponse(t *testing.T) {
 							{
 								"type": "genesisDelegation",
 								"delegate": {
-									"id": "571e042583907e06ba31d5f9e54603866e84733927341e23129a4f5a"
+									"id": "571e042583907e06ba31d5f9e54603866e84733927341e23129a4f5a",
+									"vrfVerificationKeyHash": "f577eed815c23dbb12f108a478b640631cab09a45bfb766597191bb0d73709af"
 								},
 								"issuer": {
-									"id": "fd85ee08154b867f0f8c6ed7a30ae37b3f85709421ddfbad913ea5a8",
-									"vrfVerificationKeyHash": "f577eed815c23dbb12f108a478b640631cab09a45bfb766597191bb0d73709af"
+									"id": "fd85ee08154b867f0f8c6ed7a30ae37b3f85709421ddfbad913ea5a8"
 								}
 							}
 						],
 						"withdrawals": {
 							"stake_test1uqnd9um8wq9tkss02tmgkvz5t7zhcgcafkr8mujaelkdvgg06hp3t": {
-								"lovelace": 386198
+								"ada": {
+									"lovelace": 386198
+								}
 							}
 						},
 						"mint": {
@@ -753,7 +777,9 @@ func TestPraosResponse(t *testing.T) {
 						"network": "testnet",
 						"scriptIntegrityHash": "8041fd1e79eb03cc137e4ac04c353772ab29526a346a0814969c05eb8cdbb969",
 						"fee": {
-							"lovelace": 552489
+							"ada": {
+								"lovelace": 552489
+							}
 						},
 						"validityInterval": {
 							"invalidBefore": 5
@@ -765,7 +791,9 @@ func TestPraosResponse(t *testing.T) {
 									"source": "reserves",
 									"target": "treasury",
 									"value": {
-										"lovelace": 756310
+										"ada": {
+											"lovelace": 756310
+										}
 									}
 								}
 							},
@@ -775,7 +803,9 @@ func TestPraosResponse(t *testing.T) {
 									"source": "reserves",
 									"target": "treasury",
 									"value": {
-										"lovelace": 730347
+										"ada": {
+											"lovelace": 730347
+										}
 									}
 								}
 							}
@@ -800,25 +830,33 @@ func TestPraosResponse(t *testing.T) {
 								"addressAttributes": "eb635f"
 							}
 						],
-						"redeemers": {
-							"spend:3": {
+						"redeemers": [
+							{
+								"validator": {
+									"index": 3,
+									"purpose": "spend"
+								},
 								"redeemer": "44ecd6996f",
 								"executionUnits": {
 									"memory": 5012437254351683362,
 									"cpu": 8543895173845936757
 								}
 							},
-							"mint:6": {
+							{
+								"validator": {
+									"index": 6,
+									"purpose": "mint"
+								},
 								"redeemer": "a3d87a9fa12201ff447a1bbfb842422da4437b5ab10242c05340a0a5224310eb56444ba4d7bc41872000054299ea2140234044f384dfd4427f58",
 								"executionUnits": {
 									"memory": 5139577675069485071,
 									"cpu": 1480105547444861962
 								}
 							}
-						}
+						]
 					},
 					{
-						"id": "50d9feb6e45a13f5a856913b9c6d1b63c2abc03aaabebe4055c46561d0664f0e",
+						"id": "aec47db7562b8a301d44cc19940ea128718b6df4564975df07614523ae0d03ca",
 						"spends": "collaterals",
 						"inputs": [
 							{
@@ -885,10 +923,10 @@ func TestPraosResponse(t *testing.T) {
 							"address": "addr1v9s8auaf7xrwcknzzg9ftysuhwe87qw8xg2gmcwd4l3v6dqg6ajma",
 							"value": {
 								"ada": {
-									"lovelace": 3480152061470011281
+									"lovelace": 0
 								},
 								"65d910ddf94a9322d06c0719cb9fcb541d6a2ddf44d83071bcfcdbb0": {
-									"d93c48b6d1baa662b59e5fb646c2ddafa15afbef5abfbe65d60e1711": 8472747137708736150
+									"d93c48b6d1baa662b59e5fb646c2ddafa15afbef5abfbe65d60e1711": 2653892454332976533
 								}
 							},
 							"script": {
@@ -910,10 +948,14 @@ func TestPraosResponse(t *testing.T) {
 						],
 						"withdrawals": {
 							"stake17xd7s38syqung8dqh2eu9erwcejda2y0njle0tt880ljunq6glahd": {
-								"lovelace": 893298
+								"ada": {
+									"lovelace": 893298
+								}
 							},
 							"stake1uxjy7wsp5ct2kjcpv7sec9mv6zm24mgyu4ls0rlj9rlp0wsvwx7xg": {
-								"lovelace": 367880
+								"ada": {
+									"lovelace": 367880
+								}
 							}
 						},
 						"mint": {
@@ -926,7 +968,9 @@ func TestPraosResponse(t *testing.T) {
 						],
 						"network": "mainnet",
 						"fee": {
-							"lovelace": 276885
+							"ada": {
+								"lovelace": 276885
+							}
 						},
 						"validityInterval": {
 							"invalidBefore": 6
@@ -1052,25 +1096,33 @@ func TestPraosResponse(t *testing.T) {
 						"datums": {
 							"704f836b6b652f423d42ce3232f5e82875172fc7e00f8bc27d84c2445a3a0341": "a2039f9f42640922ff9f423531230144c4e8777003ff22a2404448eb4b9a44157dad2d249f425b5e40ffff41a2d87c9fd87d80ff"
 						},
-						"redeemers": {
-							"mint:6": {
+						"redeemers": [
+							{
+								"validator": {
+									"index": 6,
+									"purpose": "mint"
+								},
 								"redeemer": "d87c80",
 								"executionUnits": {
 									"memory": 8801224258524349976,
 									"cpu": 6616915720093090519
 								}
 							},
-							"certificate:4": {
+							{
+								"validator": {
+									"index": 4,
+									"purpose": "publish"
+								},
 								"redeemer": "d87a80",
 								"executionUnits": {
 									"memory": 6358196380493345925,
 									"cpu": 8390607135841051777
 								}
 							}
-						}
+						]
 					},
 					{
-						"id": "7b5bdfa67d06142497c05d76bb6b9e98364e917637afbe764feee164ec055bb2",
+						"id": "811794abd0c2dedca0612900a9b266e23b5fcd75e001e7856206f2bcaf220c88",
 						"spends": "collaterals",
 						"inputs": [
 							{
@@ -1111,10 +1163,10 @@ func TestPraosResponse(t *testing.T) {
 								"address": "addr1z9rnpqh8akpysrf06r6hulwra7ppa8vrad293anjnd4stlgpej9pf4gc58c8tqskgxzjvapy5cfddf7ekvxlm9nwh4es0ppw0u",
 								"value": {
 									"ada": {
-										"lovelace": 2577659174567767534
+										"lovelace": 0
 									},
 									"4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-										"4e30b6e8803fa5467064ca01ffff": 7590109741623188812
+										"4e30b6e8803fa5467064ca01ffff": 1
 									}
 								},
 								"datumHash": "40985f20209c7e1882d7c241e596838ac574e6e25aef587f1820b37d8259a199",
@@ -1145,10 +1197,10 @@ func TestPraosResponse(t *testing.T) {
 							"address": "2cWKMJemoBajSt8TNJTf1YchyTTE9BjSufoWMSenBPVx91obrA2GzC8JQKtwwu24vKXdd",
 							"value": {
 								"ada": {
-									"lovelace": 3850919099990513683
+									"lovelace": 2960440386428397936
 								},
 								"98977cab9ebd32f98e2752d205da6748005f9c253fee025fcb06457d": {
-									"455d1f01": 6853692791036578420
+									"455d1f01": 1
 								}
 							},
 							"datumHash": "52e84f75d61dbf5137d2d307ad2f058fb71ae1d2508bd5eb49b5e33b52caeffc",
@@ -1161,7 +1213,9 @@ func TestPraosResponse(t *testing.T) {
 							}
 						},
 						"totalCollateral": {
-							"lovelace": 405778
+							"ada": {
+								"lovelace": 405778
+							}
 						},
 						"mint": {
 							"b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
@@ -1171,7 +1225,9 @@ func TestPraosResponse(t *testing.T) {
 						"network": "mainnet",
 						"scriptIntegrityHash": "51111abd93b1784d20d198f3d1c5743a172520ab6e095819f73a7dbf211e0d91",
 						"fee": {
-							"lovelace": 356829
+							"ada": {
+								"lovelace": 356829
+							}
 						},
 						"validityInterval": {
 							"invalidBefore": 4,
@@ -1211,29 +1267,41 @@ func TestPraosResponse(t *testing.T) {
 						"datums": {
 							"368f9390a7c19125f0e73cd5e26d40f7de9c43aa39bc6f83ccdccaed5a94cbb1": "a2a441b6a30141904206b321443ed7069405442164818343e97fc905d87b8080d87a9f0444875c79bb40ffa39f42dbef03ff9f41732124ff00a2040144c2ae37fb014196d87d9f44fac271c8ff01a203d87e9f0542dee84024ff9f43e60f0641bb44ecc3ee7000421b1dff9f000421ff"
 						},
-						"redeemers": {
-							"spend:6": {
+						"redeemers": [
+							{
+								"validator": {
+									"index": 6,
+									"purpose": "spend"
+								},
 								"redeemer": "02",
 								"executionUnits": {
 									"memory": 8173834249442977306,
 									"cpu": 4076336471699615579
 								}
 							},
-							"mint:3": {
+							{
+								"validator": {
+									"index": 3,
+									"purpose": "mint"
+								},
 								"redeemer": "9f2440ff",
 								"executionUnits": {
 									"memory": 2815464405602228167,
 									"cpu": 9135073017538346060
 								}
 							},
-							"mint:7": {
+							{
+								"validator": {
+									"index": 7,
+									"purpose": "mint"
+								},
 								"redeemer": "42ba47",
 								"executionUnits": {
 									"memory": 7350280539456537937,
 									"cpu": 474227869721943704
 								}
 							}
-						}
+						]
 					}
 				]
 			},

--- a/ouroboros/chainsync/v5/test_data/Tx_v6.json
+++ b/ouroboros/chainsync/v5/test_data/Tx_v6.json
@@ -1,5 +1,5 @@
 {
-    "id": "db82d91485a628e3732f881c79199c01ece029398329121231296e5c4ca827c6",
+    "id": "58924fded958dda8a7ac6a120f00eea7e7374ff8ce54751e4ce9db689604b90c",
     "spends": "collaterals",
     "inputs": [
         {
@@ -20,10 +20,10 @@
             "address": "addr1gx2fe5rhglqrcgf2cpn0fyuvh2cy97ax0lz3v70qv2jmgkczqqqs0pwy02",
             "value": {
                 "ada": {
-                    "lovelace": 312617921725660100
+                    "lovelace": 5471871707173873214
                 },
                 "709fc5abc5df4cfee75360cfa9f3ee7d36d6cb216a0ba4daddb16366": {
-                    "35": 3812892794721600000
+                    "35": 1
                 }
             },
             "datumHash": "3c7a5f2e2f52c4756b9b359b63b316c77e9113f635c8690bb1b506b7c9b890f2"
@@ -32,10 +32,10 @@
             "address": "addr_test1qr0y0q76tdu63exxxfhrcq00u3vpz3jfe0dnevcy5e6tlx23r7kvyuvvj8njqwhrrsv4jsw73uv0apx966rksaa66hzqpu75h5",
             "value": {
                 "ada": {
-                    "lovelace": 3531149964235084000
+                    "lovelace": 2359388962328459812
                 },
                 "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                    "f3fae0095e78ccade17ffa547dd9cd839ebe65": 2153730649591039000
+                    "f3fae0095e78ccade17ffa547dd9cd839ebe65": 1
                 }
             },
             "datumHash": "4ad8cd5be6986e6c3eb4d3f942c75e68a8e0be40e405c240781964698fca137c"
@@ -44,10 +44,10 @@
             "address": "addr1q8qgshfmdt5vkx2msf48qtvg3pgurrgxau482m2yyw0c2483lhxjm7kxtt28lhsfkd9mlwtlj3z92nm7zs3m30w7h4hqarsdu2",
             "value": {
                 "ada": {
-                    "lovelace": 4968142171704102000
+                    "lovelace": 6998929950975338793
                 },
                 "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                    "34": 7989804813950565000
+                    "34": 1
                 }
             },
             "datumHash": "0f768d10304e2488f0cf50cd5c8ac25133291b4bf36db311e7ec19bd7ef9eb65"
@@ -64,25 +64,29 @@
         {
             "type": "genesisDelegation",
             "delegate": {
-                "id": "fdefd8e3beb32cd86c84959f8e156a32a1ba3876ebdd868ad3eefb7c"
+                "id": "fdefd8e3beb32cd86c84959f8e156a32a1ba3876ebdd868ad3eefb7c",
+                "vrfVerificationKeyHash": "15f1292a444fe5aa73f95d9d75e4a1909d6aa05fca22a21174a330232ef41a29"
             },
             "issuer": {
-                "id": "50699ad21903e2cc251fdccb6641b78df70fb5972862a4597a1cb6b4",
-                "vrfVerificationKeyHash": "15f1292a444fe5aa73f95d9d75e4a1909d6aa05fca22a21174a330232ef41a29"
+                "id": "50699ad21903e2cc251fdccb6641b78df70fb5972862a4597a1cb6b4"
             }
         }
     ],
     "withdrawals": {
         "stake_test17qrerkduc7v5vt5mfz4j3vhv667q9lxv4aldhqq6v7cml0gwacue2": {
-            "lovelace": 433263
+            "ada": {
+                "lovelace": 433263
+            }
         },
         "stake178cxrn5h9fqftntssdrjh0kwd6622vlqu3h8r7tl8gnzrhsnvljkg": {
-            "lovelace": 224375
+            "ada": {
+                "lovelace": 224375
+            }
         }
     },
     "mint": {
         "39c7e3a4c1dc6032dc0ea4d471195037c85ed90b31926954cd5446c6": {
-            "1e7a8d28bb1c1988ff842ff101e2e5": 3697388719172431000
+            "1e7a8d28bb1c1988ff842ff101e2e5": 3697388719172430741
         }
     },
     "requiredExtraSignatories": [
@@ -97,7 +101,9 @@
     "network": "mainnet",
     "scriptIntegrityHash": "89fc262c4561ccabd5cfb8a9e30ba3c928b2910829b86096ba771ca387aa1d49",
     "fee": {
-        "lovelace": 464857
+        "ada": {
+            "lovelace": 464857
+        }
     },
     "validityInterval": {
         "invalidBefore": 4,
@@ -110,7 +116,9 @@
                 "source": "treasury",
                 "target": "reserves",
                 "value": {
-                    "lovelace": 142671
+                    "ada": {
+                        "lovelace": 142671
+                    }
                 }
             }
         }

--- a/ouroboros/shared/value.go
+++ b/ouroboros/shared/value.go
@@ -216,8 +216,18 @@ type Coin struct {
 	Amount  num.Int
 }
 
+func CreateAdaCoin(amt num.Int) Coin {
+	return Coin{AssetId: AdaAssetID, Amount: amt}
+}
+
 func ValueFromCoins(coins ...Coin) Value {
 	value := Value{}
 	value.AddAsset(coins...)
+	return value
+}
+
+func CreateAdaValue(amt int64) Value {
+	value := Value{}
+	value.AddAsset(CreateAdaCoin(num.Int64(amt)))
 	return value
 }

--- a/ouroboros/shared/value_test.go
+++ b/ouroboros/shared/value_test.go
@@ -69,7 +69,7 @@ func Test_AddAsset(t *testing.T) {
 	}
 	var v2 Value
 	v2.AddAsset(
-		Coin{AssetId: AdaAssetID, Amount: num.Uint64(1)},
+		CreateAdaCoin(num.Uint64(1)),
 		Coin{AssetId: FromSeparate("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "4c51"), Amount: num.Uint64(14310359231)},
 	)
 	var v3 Value


### PR DESCRIPTION
- Remove Lovelace type and replace all instances with the Value type. This change was instituted in the final Ogmios v6 release.
- Update test samples to reflect updated Ogmios sample data.
- Add helper functions that make ADA Coin and Value creation easier out of the box.
- Update v6 migration doc.
- Miscellaneous cleanup and dead code removal.