### PR TITLE
[SB-1379] Fix compatibility test regression

### DIFF
--- a/ouroboros/chainsync/types.go
+++ b/ouroboros/chainsync/types.go
@@ -456,7 +456,7 @@ type Tx struct {
 	Fee                      shared.Value            `json:"fee,omitempty"                      dynamodbav:"fee,omitempty"`
 	ValidityInterval         ValidityInterval        `json:"validityInterval"                   dynamodbav:"validityInterval,omitempty"`
 	Mint                     shared.Value            `json:"mint,omitempty"                     dynamodbav:"mint,omitempty"`
-	Network                  string                  `json:"network,omitempty"                  dynamodbav:"network,omitempty"`
+	Network                  json.RawMessage         `json:"network,omitempty"                  dynamodbav:"network,omitempty"`
 	ScriptIntegrityHash      string                  `json:"scriptIntegrityHash,omitempty"      dynamodbav:"scriptIntegrityHash,omitempty"`
 	RequiredExtraSignatories []string                `json:"requiredExtraSignatories,omitempty" dynamodbav:"requiredExtraSignatories,omitempty"`
 	RequiredExtraScripts     []string                `json:"requiredExtraScripts,omitempty"     dynamodbav:"requiredExtraScripts,omitempty"`

--- a/ouroboros/chainsync/v5/types.go
+++ b/ouroboros/chainsync/v5/types.go
@@ -124,7 +124,7 @@ func (t TxV5) ConvertToV6() chainsync.Tx {
 		Fee:                      shared.CreateAdaValue(t.Body.Fee.Int64()),
 		ValidityInterval:         t.Body.ValidityInterval.ConvertToV6(),
 		Mint:                     mint,
-		Network:                  string(t.Body.Network),
+		Network:                  t.Body.Network,
 		ScriptIntegrityHash:      t.Body.ScriptIntegrityHash,
 		RequiredExtraSignatories: t.Body.RequiredExtraSignatures,
 		RequiredExtraScripts:     nil,
@@ -145,8 +145,8 @@ func TxFromV6(t chainsync.Tx) TxV5 {
 	withdrawals := map[string]int64{}
 	for txid, amt := range t.Withdrawals {
 		for _, policyMap := range amt {
-			for _, amt := range policyMap {
-				withdrawals[txid] = amt.Int64()
+			for _, assets := range policyMap {
+				withdrawals[txid] = assets.Int64()
 			}
 		}
 	}


### PR DESCRIPTION
- Commit 051bd17 introduces a regression where CompatibleResponsePraos errored out when being marshaled. Fix by changing the Tx "Network" type back to json.RawMessage.
- Change a variable name, as discussed in a separate PR.