### PR TITLE
[SB-1626] Add metadata extraction

### DIFF
--- a/docs/MIGRATION_TO_V6.md
+++ b/docs/MIGRATION_TO_V6.md
@@ -10,7 +10,7 @@ Note that this document is a supplement to [the original Ogmios migration guide]
 There are a handful of caveats that should be considered before reading the main document.
 
 * The Ogmigo v6 upgrade adds no new major functionality beyond v6 struct support and a compatibility layer that allows both v5 and v6 Ogmigo JSON/DB/at-rest data to be unmarshalled into v6 structs. If anything wasn’t supported in Ogmigo v5, it won’t be supported in Ogmigo v6.
-* Support for the Byron era is limited in Ogmigo v6, and may not work as expected. In fact, as of this writing (Jan. 2024), critical functionality, such as the _compatibility_ module, assumes Byron _isn’t_ supported. If you must have Byron support, further Ogmigo work will be required.
+* Support for the Byron era is limited in Ogmigo v6, and may not work as expected. In fact, as of this writing (Apr). 2024), critical functionality, such as the _compatibility_ module, assumes Byron _isn’t_ supported. If you must have Byron support, further Ogmigo work will be required.
 * Any attempt to use a v6-enabled Ogmigo library will, in all likelihood, break the code using Ogmigo out of the box. Many fundamental structs (e.g., _Block_) have been altered to assume v6 structs. If somebody absolutely must use v5 structs, they’ll have to import the _v5_ module and use those structs. Even then, it is highly recommended to use the _compatibility_ module whenever possible, thereby assisting in a smooth transition to the default (v6) code.
 
 # Support for v6
@@ -94,6 +94,10 @@ for policy, policyMap := range nonAdaAssets {
     }
 }
 ```
+
+## Metadata
+
+Transaction metadata is formatted differently in v6. Incoming metadata is still treated by Ogmios as raw bytes. However, there are added structs and helper functions that allow users to get to the actual, underlying metadata. There are v5 (`OgmiosAuxiliaryDataV5`) and v6 (`OgmiosAuxiliaryDataV6`) structs, along with the `CompatibleOgmiosAuxiliaryData` struct that can be used to migrate from v5 to v6.
 
 ## FindIntersect (v5) / findIntersection (v6)
 

--- a/ouroboros/chainsync/v5/types_test.go
+++ b/ouroboros/chainsync/v5/types_test.go
@@ -15,13 +15,17 @@
 package v5
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"math/big"
 	"os"
 	"testing"
 
 	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 	"github.com/stretchr/testify/assert"
 )
+
+const TestDatumKey = 918273
 
 func TestV5(t *testing.T) {
 	t.Run("TxFromV6", func(t *testing.T) {
@@ -41,7 +45,7 @@ func TestV5(t *testing.T) {
 			bootstrapV5Sigs = append(bootstrapV5Sigs, sig)
 		}
 
-		network := "mainnet"
+		network := "\"mainnet\""
 		bootstrap := "{\"key\":\"d88f6028cc3d6d335115de3737bc2fe80a9a57a21a2c7c228ebc33b222e0897b\",\"signature\":\"/rRH7Ka4GfiLS2qsgalyABId1EUb/Mtl9z0x3ilrVALurUKEiAhjOtHUr7+tOi8ZZ85lUWrcpc03NnP3WKnAlg==\",\"chainCode\":\"12340000\",\"addressAttributes\":\"Lw==\"}"
 		assert.Equal(t, "2f", expectedV6.Signatories[0].AddressAttributes)
 		assert.Equal(t, "12340000", expectedV6.Signatories[0].ChainCode)
@@ -50,10 +54,112 @@ func TestV5(t *testing.T) {
 		assert.Equal(t, bootstrap, string(v5Conversion.Witness.Bootstrap[0]))
 		assert.Equal(t, "IFb1lTq+ivhYQz6fAoPZQXuGgebeh5fIsM8rocK03mbss8yaUQpf871Qso2aAYaxjDadDHzMfUPRCJDpTyVxQg==", v5Conversion.Witness.Signatures["400019217786c3630fb121c455065b879055aa0ced5076a24abe8d6c837e0318"])
 		assert.Equal(t, json.RawMessage(network), v5Conversion.Body.Network)
-		assert.Equal(t, network, v6Conversion.Network)
+		assert.Equal(t, json.RawMessage(network), v6Conversion.Network)
 		assert.Equal(t, expectedV6.Signatories[0].AddressAttributes, v6Conversion.Signatories[2].AddressAttributes)
 		assert.Equal(t, expectedV6.Signatories[0].ChainCode, v6Conversion.Signatories[2].ChainCode)
 		assert.Equal(t, expectedV6.Signatories[0].Key, v6Conversion.Signatories[2].Key)
 		assert.Equal(t, expectedV6.Signatories[0].Signature, v6Conversion.Signatories[2].Signature)
 	})
+}
+
+func Test_ParseOgmiosMetadataV5(t *testing.T) {
+	meta := json.RawMessage(`
+          {
+            "hash": "00",
+            "body": {
+              "blob": {
+                "918273": {
+                  "int": 123
+                }
+              }
+            }
+          }`,
+	)
+
+	var o OgmiosAuxiliaryDataV5
+	err := json.Unmarshal(meta, &o)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, big.NewInt(123).Cmp(o.Body.Blob[TestDatumKey].IntField))
+}
+
+func Test_ParseOgmiosMetadataMapV5(t *testing.T) {
+	meta := json.RawMessage(`
+          {
+            "hash": "00",
+            "body": {
+              "blob": {
+                "918273": {
+                  "map": [
+                    {
+                      "k": { "int": 1 },
+                      "v": { "string": "foo" }
+                    },
+                    {
+                      "k": { "int": 2 },
+                      "v": { "string": "bar" }
+                    }
+                  ]
+                }
+              }
+            }
+          }`,
+	)
+
+	var o OgmiosAuxiliaryDataV5
+	err := json.Unmarshal(meta, &o)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, big.NewInt(1).Cmp(o.Body.Blob[TestDatumKey].MapField[0].Key.IntField))
+}
+
+func Test_GetDatumBytesV5(t *testing.T) {
+	meta := json.RawMessage(`
+          {
+            "hash": "00",
+            "body": {
+              "blob": {
+                "918273": {
+                  "map": [
+                    {
+                      "k": {
+                        "bytes": "5e60a2d4ebe669605f5b9cc95844122749fb655970af9ef30aad74f6abc7455e"
+                      },
+                      "v": {
+                        "list":
+                          [
+                            {
+                              "bytes": "d8799f4100d8799fd8799fd8799fd8799f581c694bc6017f9d74a5d9b3ef377b42b9fe4967a04fb1844959057f35bbffd87a80ffd87a80ffd8799f581c694bc6"
+                            },
+                            {
+                              "bytes": "017f9d74a5d9b3ef377b42b9fe4967a04fb1844959057f35bbffff1a002625a0d87b9fd87a9fd8799f1a0007a1201a006312c3ffffffff"
+                            }
+                          ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }`,
+	)
+	bytes :=
+		"d8799f4100d8799fd8799fd8799fd8799" +
+			"f581c694bc6017f9d74a5d9b3ef377b42" +
+			"b9fe4967a04fb1844959057f35bbffd87" +
+			"a80ffd87a80ffd8799f581c694bc6017f" +
+			"9d74a5d9b3ef377b42b9fe4967a04fb18" +
+			"44959057f35bbffff1a002625a0d87b9f" +
+			"d87a9fd8799f1a0007a1201a006312c3f" +
+			"fffffff"
+	expected, err := hex.DecodeString(bytes)
+	assert.Nil(t, err)
+	datumBytes, err := GetMetadataDatumsV5(meta, TestDatumKey)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, datumBytes[0])
+}
+
+func Test_UnmarshalOgmiosMetadataV5(t *testing.T) {
+	meta := json.RawMessage(`{"674":{"map":[{"k":{"string":"msg"},"v":{"list":[{"string":"MuesliSwap Place Order"}]}}]},"1000":{"bytes":"01046034bf780d7e1a39a6ea628c54d70744664111947bfa319072b92d14f063133083b727c9f1b2e83c899982cc66da7aafd748e02206b849"},"1002":{"string":""},"1003":{"string":""},"1004":{"int":-949318},"1005":{"int":2650000},"1007":{"int":1},"1008":{"string":"547ceed647f57e64dc40a29b16be4f36b0d38b5aa3cd7afb286fc094"},"1009":{"string":"6262486f736b79"}}`)
+	var o OgmiosMetadataV5
+	err := json.Unmarshal(meta, &o)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
- Add the ability to extract the metadata from v5 and v6 transactions, and a compatibility module to assist with transitions to v6.
- Add appropriate unit tests.
- Fix up a couple of broken unit tests.