### PR TITLE
fix: golangci-lint identified issues

### DIFF
--- a/ouroboros/chainsync/num/int_test.go
+++ b/ouroboros/chainsync/num/int_test.go
@@ -33,6 +33,9 @@ func TestDeserializeValue(t *testing.T) {
 
 	var got Value
 	err = json.Unmarshal(data, &got)
+	if err != nil {
+		t.Fatalf("got %#v; want %#v", got, want)
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %#v; want %#v", got, want)
 	}

--- a/ouroboros/chainsync/types.go
+++ b/ouroboros/chainsync/types.go
@@ -34,7 +34,6 @@ import (
 )
 
 var (
-	encOptions = cbor.CoreDetEncOptions()
 	bNil       = []byte("nil")
 )
 

--- a/ouroboros/chainsync/types_test.go
+++ b/ouroboros/chainsync/types_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -45,6 +44,9 @@ func TestUnmarshal(t *testing.T) {
 
 func assertStructMatchesSchema(t *testing.T) filepath.WalkFunc {
 	return func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() {
 			return nil
 		}
@@ -76,6 +78,9 @@ func TestDynamodbSerialize(t *testing.T) {
 
 func assertDynamoDBSerialize(t *testing.T) filepath.WalkFunc {
 	return func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() {
 			return nil
 		}
@@ -508,7 +513,7 @@ func TestVasil_DatumParsing_Hex(t *testing.T) {
 }
 
 func TestVasil_BackwardsCompatibleWithExistingDynamoDB(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/scoop.json")
+	data, err := os.ReadFile("testdata/scoop.json")
 	assert.Nil(t, err)
 
 	var item map[string]*dynamodb.AttributeValue

--- a/ouroboros/statequery/types.go
+++ b/ouroboros/statequery/types.go
@@ -10,8 +10,8 @@ import (
 
 type EraStart struct {
 	Time  time.Duration `json:"time,omitempty"`
-	Slot  uint64        `json:"slot,omit"`
-	Epoch uint64        `json:"epoch,omit"`
+	Slot  uint64        `json:"slot,omitempty"`
+	Epoch uint64        `json:"epoch,omitempty"`
 }
 
 type Utxo struct {

--- a/state_query_test.go
+++ b/state_query_test.go
@@ -136,5 +136,5 @@ func TestClient_UtxosByAddress(t *testing.T) {
 
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
-	encoder.Encode(utxos)
+	_ = encoder.Encode(utxos)
 }

--- a/tx_submission_test.go
+++ b/tx_submission_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,7 +55,7 @@ func testSubmitTxResult(t *testing.T) filepath.WalkFunc {
 				return
 			}
 
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("got %v; want nil", err)
 			}


### PR DESCRIPTION
Fixes unchecked errors, uncaptured errors, unused variables, and deprecated io/ioutil usage.