### PR TITLE
ci: swallow encoder error

### DIFF
--- a/state_query_test.go
+++ b/state_query_test.go
@@ -181,5 +181,5 @@ func TestClient_UtxosByTxIn(t *testing.T) {
 
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
-	encoder.Encode(utxos)
+	_ = encoder.Encode(utxos)
 }


### PR DESCRIPTION
With this, the code passes a default `golangci-lint` run.