### PR TITLE
chore: make format golines

### DIFF
--- a/chain_sync_test.go
+++ b/chain_sync_test.go
@@ -50,7 +50,9 @@ func TestClient_ChainSync(t *testing.T) {
 	client := New(WithEndpoint(endpoint))
 	var callback ChainSyncFunc = func(ctx context.Context, data []byte) error {
 		var response chainsync.ResponsePraos
-		decoder := json.NewDecoder(bytes.NewReader(data)) // use decoder to check for unknown fields
+		decoder := json.NewDecoder(
+			bytes.NewReader(data),
+		) // use decoder to check for unknown fields
 		decoder.DisallowUnknownFields()
 
 		err := decoder.Decode(&response)
@@ -66,7 +68,12 @@ func TestClient_ChainSync(t *testing.T) {
 			if nbr.Direction == chainsync.RollForwardString {
 				blockNo = nbr.Block.Height
 			}
-			log.Printf("read: block=%v, n=%v, read=%v", blockNo, p.Sprintf("%d", v), p.Sprintf("%d", read))
+			log.Printf(
+				"read: block=%v, n=%v, read=%v",
+				blockNo,
+				p.Sprintf("%d", v),
+				p.Sprintf("%d", read),
+			)
 		}
 
 		return nil

--- a/cmd/test_client/main.go
+++ b/cmd/test_client/main.go
@@ -26,7 +26,10 @@ func main() {
 
 		switch response.Method {
 		case chainsync.FindIntersectionMethod, chainsync.FindIntersectMethod:
-			fmt.Printf("CompatibleResultFindIntersection - %v\n", response.Result)
+			fmt.Printf(
+				"CompatibleResultFindIntersection - %v\n",
+				response.Result,
+			)
 		case chainsync.NextBlockMethod, chainsync.RequestNextMethod:
 			fmt.Printf("CompatibleResultNextBlock - %v\n", response.Result)
 		default:
@@ -86,7 +89,11 @@ func main() {
 		return
 	}
 	if *debugPtr {
-		fmt.Printf("GOT THE ERA SUMMARIES - %v - %v\n", summaries.Summaries[len(summaries.Summaries)-1].Start.Slot, summaries.Summaries[len(summaries.Summaries)-1].End.Slot)
+		fmt.Printf(
+			"GOT THE ERA SUMMARIES - %v - %v\n",
+			summaries.Summaries[len(summaries.Summaries)-1].Start.Slot,
+			summaries.Summaries[len(summaries.Summaries)-1].End.Slot,
+		)
 	}
 
 	start, err := my_client.EraStart(ctx)

--- a/ouroboros/chainsync/compatibility/types.go
+++ b/ouroboros/chainsync/compatibility/types.go
@@ -43,7 +43,8 @@ func (c *CompatibleResultFindIntersection) UnmarshalJSON(data []byte) error {
 
 	var r5 v5.ResultFindIntersectionV5
 	err2 := json.Unmarshal(data, &r5)
-	if err2 == nil && (r5.IntersectionFound != nil || r5.IntersectionNotFound != nil) {
+	if err2 == nil &&
+		(r5.IntersectionFound != nil || r5.IntersectionNotFound != nil) {
 		*c = CompatibleResultFindIntersection(r5.ConvertToV6())
 		return nil
 	} else {
@@ -80,7 +81,9 @@ func (c CompatibleResultFindIntersection) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&five)
 }
 
-func (c *CompatibleResultFindIntersection) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c *CompatibleResultFindIntersection) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	var s chainsync.ResultFindIntersectionPraos
 	err := dynamodbattribute.Unmarshal(item, &s)
 	if err == nil && s.Intersection != nil {
@@ -98,7 +101,9 @@ func (c *CompatibleResultFindIntersection) UnmarshalDynamoDBAttributeValue(item 
 	}
 }
 
-func (c CompatibleResultFindIntersection) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c CompatibleResultFindIntersection) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	six := chainsync.ResultFindIntersectionPraos(c)
 	five := v5.ResultFindIntersectionFromV6(six)
 	av, err := dynamodbattribute.Marshal(&five)
@@ -110,7 +115,13 @@ func (c CompatibleResultFindIntersection) MarshalDynamoDBAttributeValue(item *dy
 }
 
 func (c CompatibleResultFindIntersection) String() string {
-	return fmt.Sprintf("intersection=[%v] tip=[%v] error=[%v] id=[%v]", c.Intersection, c.Tip, c.Error, c.ID)
+	return fmt.Sprintf(
+		"intersection=[%v] tip=[%v] error=[%v] id=[%v]",
+		c.Intersection,
+		c.Tip,
+		c.Error,
+		c.ID,
+	)
 }
 
 // Support nextBlock (v6) / RequestNext (v5) universally.
@@ -141,7 +152,9 @@ func (c CompatibleResultNextBlock) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&five)
 }
 
-func (c *CompatibleResultNextBlock) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c *CompatibleResultNextBlock) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	var s chainsync.ResultNextBlockPraos
 	err := dynamodbattribute.Unmarshal(item, &s)
 	if err == nil && s.Direction != "" {
@@ -159,7 +172,9 @@ func (c *CompatibleResultNextBlock) UnmarshalDynamoDBAttributeValue(item *dynamo
 	}
 }
 
-func (c CompatibleResultNextBlock) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c CompatibleResultNextBlock) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	six := chainsync.ResultNextBlockPraos(c)
 	five := v5.ResultNextBlockFromV6(six)
 	av, err := dynamodbattribute.Marshal(&five)
@@ -171,7 +186,13 @@ func (c CompatibleResultNextBlock) MarshalDynamoDBAttributeValue(item *dynamodb.
 }
 
 func (c CompatibleResultNextBlock) String() string {
-	return fmt.Sprintf("direction=[%v] tip=[%v] block=[%v] point=[%v]", c.Direction, c.Tip, c.Block, c.Point)
+	return fmt.Sprintf(
+		"direction=[%v] tip=[%v] block=[%v] point=[%v]",
+		c.Direction,
+		c.Tip,
+		c.Block,
+		c.Point,
+	)
 }
 
 // Frontend for converting v5 JSON responses to v6.
@@ -201,7 +222,9 @@ func (c CompatibleResponsePraos) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v5.ResponseFromV6(six))
 }
 
-func (c *CompatibleResponsePraos) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c *CompatibleResponsePraos) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	var s chainsync.ResponsePraos
 	if err := dynamodbattribute.Unmarshal(item, &s); err != nil {
 		var v v5.ResponseV5
@@ -215,7 +238,9 @@ func (c *CompatibleResponsePraos) UnmarshalDynamoDBAttributeValue(item *dynamodb
 	return nil
 }
 
-func (c CompatibleResponsePraos) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c CompatibleResponsePraos) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	six := chainsync.ResponsePraos(c)
 	five := v5.ResponseFromV6(six)
 	av, err := dynamodbattribute.Marshal(&five)
@@ -228,7 +253,12 @@ func (c CompatibleResponsePraos) MarshalDynamoDBAttributeValue(item *dynamodb.At
 
 func (r CompatibleResponsePraos) MustFindIntersectResult() CompatibleResultFindIntersection {
 	if r.Method != chainsync.FindIntersectionMethod {
-		panic(fmt.Errorf("must only use *Must* methods after switching on the findIntersection method; called on %v", r.Method))
+		panic(
+			fmt.Errorf(
+				"must only use *Must* methods after switching on the findIntersection method; called on %v",
+				r.Method,
+			),
+		)
 	}
 	t, ok := r.Result.(chainsync.ResultFindIntersectionPraos)
 	if ok {
@@ -243,7 +273,12 @@ func (r CompatibleResponsePraos) MustFindIntersectResult() CompatibleResultFindI
 
 func (r CompatibleResponsePraos) MustNextBlockResult() CompatibleResultNextBlock {
 	if r.Method != chainsync.NextBlockMethod {
-		panic(fmt.Errorf("must only use *Must* methods after switching on the nextBlock method; called on %v", r.Method))
+		panic(
+			fmt.Errorf(
+				"must only use *Must* methods after switching on the nextBlock method; called on %v",
+				r.Method,
+			),
+		)
 	}
 	t, ok := r.Result.(chainsync.ResultNextBlockPraos)
 	if ok {
@@ -289,7 +324,9 @@ func (c CompatibleValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&s)
 }
 
-func (c *CompatibleValue) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c *CompatibleValue) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	var s shared.Value
 	if err := dynamodbattribute.Unmarshal(item, &s); err != nil {
 		var v v5.ValueV5
@@ -303,7 +340,9 @@ func (c *CompatibleValue) UnmarshalDynamoDBAttributeValue(item *dynamodb.Attribu
 	return nil
 }
 
-func (c CompatibleValue) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c CompatibleValue) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	s := v5.ValueFromV6(shared.Value(c))
 	av, err := dynamodbattribute.Marshal(&s)
 	if err != nil {
@@ -336,7 +375,11 @@ func (c *CompatibleResult) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return fmt.Errorf("unable to find an appropriate result: '%w'; '%w'", err1, err2)
+	return fmt.Errorf(
+		"unable to find an appropriate result: '%w'; '%w'",
+		err1,
+		err2,
+	)
 }
 
 func (c CompatibleResult) MarshalJSON() ([]byte, error) {
@@ -349,7 +392,9 @@ func (c CompatibleResult) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("unable to marshal empty result")
 }
 
-func (c *CompatibleResult) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c *CompatibleResult) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	var rfi CompatibleResultFindIntersection
 	r := CompatibleResult{}
 	if err := dynamodbattribute.Unmarshal(item, &rfi); err != nil {
@@ -366,7 +411,9 @@ func (c *CompatibleResult) UnmarshalDynamoDBAttributeValue(item *dynamodb.Attrib
 	return nil
 }
 
-func (c CompatibleResult) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c CompatibleResult) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	if c.NextBlock != nil {
 		return c.NextBlock.MarshalDynamoDBAttributeValue(item)
 	}
@@ -408,7 +455,9 @@ func (c CompatibleTx) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&five)
 }
 
-func (c *CompatibleTx) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c *CompatibleTx) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	var tx chainsync.Tx
 	err := dynamodbattribute.Unmarshal(item, &tx)
 	// We check spends here, as that key is distinct from the other result types.
@@ -427,7 +476,9 @@ func (c *CompatibleTx) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeV
 	}
 }
 
-func (c CompatibleTx) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c CompatibleTx) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	f := v5.TxFromV6(chainsync.Tx(c))
 
 	av, err := dynamodbattribute.Marshal(&f)
@@ -469,7 +520,9 @@ func (to CompatibleTxOut) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&five)
 }
 
-func (to *CompatibleTxOut) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (to *CompatibleTxOut) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	var txOut chainsync.TxOut
 	err := dynamodbattribute.Unmarshal(item, &txOut)
 	// We check spends here, as that key is distinct from the other result types.
@@ -488,7 +541,9 @@ func (to *CompatibleTxOut) UnmarshalDynamoDBAttributeValue(item *dynamodb.Attrib
 	}
 }
 
-func (to CompatibleTxOut) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (to CompatibleTxOut) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	f := v5.TxOutFromV6(chainsync.TxOut(to))
 
 	av, err := dynamodbattribute.Marshal(&f)
@@ -501,7 +556,10 @@ func (to CompatibleTxOut) MarshalDynamoDBAttributeValue(item *dynamodb.Attribute
 
 type CompatibleOgmiosAuxiliaryData chainsync.OgmiosAuxiliaryDataV6
 
-func GetMetadataDatums(txMetadata json.RawMessage, metadataDatumKey int) ([][]byte, error) {
+func GetMetadataDatums(
+	txMetadata json.RawMessage,
+	metadataDatumKey int,
+) ([][]byte, error) {
 	datums, err := GetMetadataDatumMap(txMetadata, metadataDatumKey)
 	if err != nil {
 		return nil, err
@@ -509,7 +567,10 @@ func GetMetadataDatums(txMetadata json.RawMessage, metadataDatumKey int) ([][]by
 	return chainsync.GetMetadataDatums(datums)
 }
 
-func GetMetadataDatumMap(txMetadata json.RawMessage, metadataDatumKey int) (map[string][]byte, error) {
+func GetMetadataDatumMap(
+	txMetadata json.RawMessage,
+	metadataDatumKey int,
+) (map[string][]byte, error) {
 	if txMetadata == nil {
 		return map[string][]byte{}, nil
 	}
@@ -535,7 +596,11 @@ func GetMetadataDatumMap(txMetadata json.RawMessage, metadataDatumKey int) (map[
 		return nil, nil
 	}
 	if dats.Json == nil {
-		return nil, fmt.Errorf("transaction metadata at key '%d' is missing a json representation: '%v' (is ogmios running with --metadata-detailed-schema?)", metadataDatumKey, string(txMetadata))
+		return nil, fmt.Errorf(
+			"transaction metadata at key '%d' is missing a json representation: '%v' (is ogmios running with --metadata-detailed-schema?)",
+			metadataDatumKey,
+			string(txMetadata),
+		)
 	}
 	return chainsync.ReconstructDatums(*(dats.Json))
 }
@@ -571,7 +636,9 @@ func (c CompatibleOgmiosAuxiliaryData) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&five)
 }
 
-func (c *CompatibleOgmiosAuxiliaryData) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c *CompatibleOgmiosAuxiliaryData) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	var metadata chainsync.OgmiosAuxiliaryDataV6
 	err := dynamodbattribute.Unmarshal(item, &metadata)
 	// We check spends here, as that key is distinct from the other result types.
@@ -590,7 +657,9 @@ func (c *CompatibleOgmiosAuxiliaryData) UnmarshalDynamoDBAttributeValue(item *dy
 	}
 }
 
-func (c CompatibleOgmiosAuxiliaryData) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (c CompatibleOgmiosAuxiliaryData) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	f, err := v5.OgmiosAuxiliaryDataFromV6(chainsync.OgmiosAuxiliaryDataV6(c))
 	if err != nil {
 		return err

--- a/ouroboros/chainsync/compatibility/types_test.go
+++ b/ouroboros/chainsync/compatibility/types_test.go
@@ -48,30 +48,122 @@ func TestCompatibleResult(t *testing.T) {
 		var compatible CompatibleResultNextBlock
 		err = json.Unmarshal(rawData, &compatible)
 		assert.Nil(t, err)
-		assert.Equal(t, "", compatible.Block.Transactions[0].Signatories[0].AddressAttributes)
-		assert.Equal(t, "909d", compatible.Block.Transactions[0].Signatories[0].ChainCode)
-		assert.Equal(t, "16d35a2dffb176e89d67ac7e7fca602f1deb5059f2edf48673108d72478f62e5", compatible.Block.Transactions[0].Signatories[0].Key)
-		assert.Equal(t, "e62e507db48986e427ccdda40b108df6dab84ce9a0f67377b92a71e5ff05db05aa6425a8ffdbbf5eef761e8c05f07d9fed8d2376f5c775123f55f595eb3fab66", compatible.Block.Transactions[0].Signatories[0].Signature)
-		assert.Equal(t, "fd", compatible.Block.Transactions[0].Signatories[1].AddressAttributes)
-		assert.Equal(t, "ac", compatible.Block.Transactions[0].Signatories[1].ChainCode)
-		assert.Equal(t, "7b5cb6d898502a692d256255efd9155053fa4ad247c3f74d152a67884e2c2424", compatible.Block.Transactions[0].Signatories[1].Key)
-		assert.Equal(t, "7650a7f156ce1be903249edf929f6d75bfc687f0613d33191d51bd4eb7ac32f41e189b9860dd49e76423abd3935dbb02ce9a52561426ffae7320149fafe35e65", compatible.Block.Transactions[0].Signatories[1].Signature)
-		assert.Equal(t, "aac4", compatible.Block.Transactions[0].Signatories[2].AddressAttributes)
-		assert.Equal(t, "7c", compatible.Block.Transactions[0].Signatories[2].ChainCode)
-		assert.Equal(t, "aa54eddec8234ca7a0205fd1262c0a7fc7e8ce56cb0edaba5ca2b66f58d8d8cf", compatible.Block.Transactions[0].Signatories[2].Key)
-		assert.Equal(t, "0b20ac60eac2a661b35ababd54d1722d0c2702535a53b5030a08f12be2cea1094175297261d9f9f1b1fced79edadc1470e4e13cc75d5f915722d6856fcaac6a9", compatible.Block.Transactions[0].Signatories[2].Signature)
-		assert.Equal(t, "d7ca16cc9549ae4f4fad53ab776a2dd2af25fa88de648d5ad7a18b106ab0bafc", compatible.Block.Transactions[0].Signatories[3].Key)
-		assert.Equal(t, "d6efd97e2a770eb79bb8ceb595920f6aab445b7a8b45ccf33f1f32016ca5f07620d27189ac93c275f22d7ed4521bd191f8166c59730081dab5eaa7d8e50ee0d0", compatible.Block.Transactions[0].Signatories[3].Signature)
-		assert.Equal(t, "d85d", compatible.Block.Transactions[1].Signatories[0].AddressAttributes)
-		assert.Equal(t, "", compatible.Block.Transactions[1].Signatories[0].ChainCode)
-		assert.Equal(t, "63176c55566a62e8bf7f7d93d7d890623fac8b46852501fe9317082619e7ee0a", compatible.Block.Transactions[1].Signatories[0].Key)
-		assert.Equal(t, "42e01143eadc791d481b04fe6c378692ec01b7e53bf45301b13886ac05d823f0672762c9d857b764fbcf19e7fbaa85db8bddf4642e7dbedefbb1e5e2b910578d", compatible.Block.Transactions[1].Signatories[0].Signature)
-		assert.Equal(t, "41b5", compatible.Block.Transactions[2].Signatories[0].AddressAttributes)
-		assert.Equal(t, "", compatible.Block.Transactions[2].Signatories[0].ChainCode)
-		assert.Equal(t, "440a92ff267209984b3c6afbee9c7d2390c91aa8ca92317e9113d6bba7ad8c4f", compatible.Block.Transactions[2].Signatories[0].Key)
-		assert.Equal(t, "5c48435bfa8699465a57ba2dfe23e1c28e17c5a2a23078458f96c8ab4e3484d2e71c58611dc7cb5004c08ff48ac3e3bae51314e13c6c8fdb4f23a53ac2fcb5f6", compatible.Block.Transactions[2].Signatories[0].Signature)
+		assert.Equal(
+			t,
+			"",
+			compatible.Block.Transactions[0].Signatories[0].AddressAttributes,
+		)
+		assert.Equal(
+			t,
+			"909d",
+			compatible.Block.Transactions[0].Signatories[0].ChainCode,
+		)
+		assert.Equal(
+			t,
+			"16d35a2dffb176e89d67ac7e7fca602f1deb5059f2edf48673108d72478f62e5",
+			compatible.Block.Transactions[0].Signatories[0].Key,
+		)
+		assert.Equal(
+			t,
+			"e62e507db48986e427ccdda40b108df6dab84ce9a0f67377b92a71e5ff05db05aa6425a8ffdbbf5eef761e8c05f07d9fed8d2376f5c775123f55f595eb3fab66",
+			compatible.Block.Transactions[0].Signatories[0].Signature,
+		)
+		assert.Equal(
+			t,
+			"fd",
+			compatible.Block.Transactions[0].Signatories[1].AddressAttributes,
+		)
+		assert.Equal(
+			t,
+			"ac",
+			compatible.Block.Transactions[0].Signatories[1].ChainCode,
+		)
+		assert.Equal(
+			t,
+			"7b5cb6d898502a692d256255efd9155053fa4ad247c3f74d152a67884e2c2424",
+			compatible.Block.Transactions[0].Signatories[1].Key,
+		)
+		assert.Equal(
+			t,
+			"7650a7f156ce1be903249edf929f6d75bfc687f0613d33191d51bd4eb7ac32f41e189b9860dd49e76423abd3935dbb02ce9a52561426ffae7320149fafe35e65",
+			compatible.Block.Transactions[0].Signatories[1].Signature,
+		)
+		assert.Equal(
+			t,
+			"aac4",
+			compatible.Block.Transactions[0].Signatories[2].AddressAttributes,
+		)
+		assert.Equal(
+			t,
+			"7c",
+			compatible.Block.Transactions[0].Signatories[2].ChainCode,
+		)
+		assert.Equal(
+			t,
+			"aa54eddec8234ca7a0205fd1262c0a7fc7e8ce56cb0edaba5ca2b66f58d8d8cf",
+			compatible.Block.Transactions[0].Signatories[2].Key,
+		)
+		assert.Equal(
+			t,
+			"0b20ac60eac2a661b35ababd54d1722d0c2702535a53b5030a08f12be2cea1094175297261d9f9f1b1fced79edadc1470e4e13cc75d5f915722d6856fcaac6a9",
+			compatible.Block.Transactions[0].Signatories[2].Signature,
+		)
+		assert.Equal(
+			t,
+			"d7ca16cc9549ae4f4fad53ab776a2dd2af25fa88de648d5ad7a18b106ab0bafc",
+			compatible.Block.Transactions[0].Signatories[3].Key,
+		)
+		assert.Equal(
+			t,
+			"d6efd97e2a770eb79bb8ceb595920f6aab445b7a8b45ccf33f1f32016ca5f07620d27189ac93c275f22d7ed4521bd191f8166c59730081dab5eaa7d8e50ee0d0",
+			compatible.Block.Transactions[0].Signatories[3].Signature,
+		)
+		assert.Equal(
+			t,
+			"d85d",
+			compatible.Block.Transactions[1].Signatories[0].AddressAttributes,
+		)
+		assert.Equal(
+			t,
+			"",
+			compatible.Block.Transactions[1].Signatories[0].ChainCode,
+		)
+		assert.Equal(
+			t,
+			"63176c55566a62e8bf7f7d93d7d890623fac8b46852501fe9317082619e7ee0a",
+			compatible.Block.Transactions[1].Signatories[0].Key,
+		)
+		assert.Equal(
+			t,
+			"42e01143eadc791d481b04fe6c378692ec01b7e53bf45301b13886ac05d823f0672762c9d857b764fbcf19e7fbaa85db8bddf4642e7dbedefbb1e5e2b910578d",
+			compatible.Block.Transactions[1].Signatories[0].Signature,
+		)
+		assert.Equal(
+			t,
+			"41b5",
+			compatible.Block.Transactions[2].Signatories[0].AddressAttributes,
+		)
+		assert.Equal(
+			t,
+			"",
+			compatible.Block.Transactions[2].Signatories[0].ChainCode,
+		)
+		assert.Equal(
+			t,
+			"440a92ff267209984b3c6afbee9c7d2390c91aa8ca92317e9113d6bba7ad8c4f",
+			compatible.Block.Transactions[2].Signatories[0].Key,
+		)
+		assert.Equal(
+			t,
+			"5c48435bfa8699465a57ba2dfe23e1c28e17c5a2a23078458f96c8ab4e3484d2e71c58611dc7cb5004c08ff48ac3e3bae51314e13c6c8fdb4f23a53ac2fcb5f6",
+			compatible.Block.Transactions[2].Signatories[0].Signature,
+		)
 
-		assert.EqualValues(t, expected.ConvertToV6(), chainsync.ResultNextBlockPraos(compatible))
+		assert.EqualValues(
+			t,
+			expected.ConvertToV6(),
+			chainsync.ResultNextBlockPraos(compatible),
+		)
 
 		bytes, err := json.Marshal(&compatible)
 		assert.Nil(t, err)
@@ -84,7 +176,11 @@ func TestCompatibleResult(t *testing.T) {
 		// this is super awkward, so we just check a few important properties
 		assert.NotNil(t, got.RollForward)
 		assert.NotNil(t, got.RollForward.Block.Babbage)
-		assert.Equal(t, got.RollForward.Block.Babbage.HeaderHash, got.RollForward.Block.Babbage.HeaderHash)
+		assert.Equal(
+			t,
+			got.RollForward.Block.Babbage.HeaderHash,
+			got.RollForward.Block.Babbage.HeaderHash,
+		)
 	})
 
 	t.Run("Roll Backward V5", func(t *testing.T) {
@@ -109,7 +205,11 @@ func TestCompatibleResult(t *testing.T) {
 		assert.Nil(t, err)
 
 		assert.NotNil(t, got.RollBackward)
-		assert.EqualValues(t, got.RollBackward.Point.String(), expected.RollBackward.Point.String())
+		assert.EqualValues(
+			t,
+			got.RollBackward.Point.String(),
+			expected.RollBackward.Point.String(),
+		)
 	})
 
 	t.Run("Roll Forward V6", func(t *testing.T) {
@@ -135,7 +235,11 @@ func TestCompatibleResult(t *testing.T) {
 
 		assert.NotNil(t, got.RollForward)
 		assert.NotNil(t, got.RollForward.Block.Allegra)
-		assert.Equal(t, got.RollForward.Block.Allegra.HeaderHash, got.RollForward.Block.Allegra.HeaderHash)
+		assert.Equal(
+			t,
+			got.RollForward.Block.Allegra.HeaderHash,
+			got.RollForward.Block.Allegra.HeaderHash,
+		)
 	})
 
 	t.Run("Roll Backward V6", func(t *testing.T) {
@@ -160,7 +264,11 @@ func TestCompatibleResult(t *testing.T) {
 		assert.Nil(t, err)
 
 		assert.NotNil(t, got.RollBackward)
-		assert.EqualValues(t, got.RollBackward.Point.ConvertToV6(), *expected.Point)
+		assert.EqualValues(
+			t,
+			got.RollBackward.Point.ConvertToV6(),
+			*expected.Point,
+		)
 	})
 
 	t.Run("Intersection Found V5", func(t *testing.T) {
@@ -186,7 +294,11 @@ func TestCompatibleResult(t *testing.T) {
 
 		assert.NotNil(t, got.IntersectionFound)
 		assert.NotNil(t, got.IntersectionFound.Tip)
-		assert.Equal(t, got.IntersectionFound.Tip.Hash, expected.IntersectionFound.Tip.Hash)
+		assert.Equal(
+			t,
+			got.IntersectionFound.Tip.Hash,
+			expected.IntersectionFound.Tip.Hash,
+		)
 	})
 
 	t.Run("Intersection Not Found V5", func(t *testing.T) {
@@ -212,7 +324,11 @@ func TestCompatibleResult(t *testing.T) {
 
 		assert.NotNil(t, got.IntersectionNotFound)
 		assert.NotNil(t, got.IntersectionNotFound.Tip)
-		assert.Equal(t, got.IntersectionNotFound.Tip.Hash, expected.IntersectionNotFound.Tip.Hash)
+		assert.Equal(
+			t,
+			got.IntersectionNotFound.Tip.Hash,
+			expected.IntersectionNotFound.Tip.Hash,
+		)
 	})
 
 	t.Run("Intersection Found V6", func(t *testing.T) {
@@ -266,7 +382,9 @@ func TestCompatibleResult(t *testing.T) {
 	})
 
 	t.Run("Real World Intersection Found", func(t *testing.T) {
-		dataV5Result, err := os.ReadFile("test_data/RealWorld_IntersectionFound_v5.json")
+		dataV5Result, err := os.ReadFile(
+			"test_data/RealWorld_IntersectionFound_v5.json",
+		)
 		assert.Nil(t, err)
 		var method9 CompatibleResult
 		err = json.Unmarshal([]byte(dataV5Result), &method9)
@@ -274,7 +392,9 @@ func TestCompatibleResult(t *testing.T) {
 	})
 
 	t.Run("Real World RollForward", func(t *testing.T) {
-		dataV5Result, err := os.ReadFile("test_data/RealWorld_RollForward_v5.json")
+		dataV5Result, err := os.ReadFile(
+			"test_data/RealWorld_RollForward_v5.json",
+		)
 		assert.Nil(t, err)
 		var method10 CompatibleResult
 		err = json.Unmarshal([]byte(dataV5Result), &method10)
@@ -282,7 +402,9 @@ func TestCompatibleResult(t *testing.T) {
 	})
 
 	t.Run("Real World Taste Test", func(t *testing.T) {
-		example, err := os.ReadFile("test_data/RealWorld_TasteTest_RollForward_v5.json")
+		example, err := os.ReadFile(
+			"test_data/RealWorld_TasteTest_RollForward_v5.json",
+		)
 		assert.Nil(t, err)
 		var result CompatibleResult
 		err = json.Unmarshal([]byte(example), &result)
@@ -456,11 +578,17 @@ func Test_ValueChecks(t *testing.T) {
 	t.Run("string", func(t *testing.T) {
 		equal1 := shared.ValueFromCoins(
 			shared.CreateAdaCoin(num.Int64(1000000)),
-			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
+			shared.Coin{
+				AssetId: shared.FromSeparate("abra", "cadabra"),
+				Amount:  num.Int64(1234567890),
+			},
 		)
 		equal2 := shared.ValueFromCoins(
 			shared.CreateAdaCoin(num.Int64(1000000)),
-			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
+			shared.Coin{
+				AssetId: shared.FromSeparate("abra", "cadabra"),
+				Amount:  num.Int64(1234567890),
+			},
 		)
 		if !shared.Equal(equal1, equal2) {
 			t.Fatalf("%v and %v are not equal", equal1, equal2)
@@ -468,19 +596,31 @@ func Test_ValueChecks(t *testing.T) {
 
 		val1 := shared.ValueFromCoins(
 			shared.CreateAdaCoin(num.Int64(1000001)),
-			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
+			shared.Coin{
+				AssetId: shared.FromSeparate("abra", "cadabra"),
+				Amount:  num.Int64(1234567890),
+			},
 		)
 		val2 := shared.ValueFromCoins(
 			shared.CreateAdaCoin(num.Int64(1000000)),
-			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
+			shared.Coin{
+				AssetId: shared.FromSeparate("abra", "cadabra"),
+				Amount:  num.Int64(1234567890),
+			},
 		)
 		val3 := shared.ValueFromCoins(
 			shared.CreateAdaCoin(num.Int64(1000000)),
-			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(12345678900)},
+			shared.Coin{
+				AssetId: shared.FromSeparate("abra", "cadabra"),
+				Amount:  num.Int64(12345678900),
+			},
 		)
 		val4 := shared.ValueFromCoins(
 			shared.CreateAdaCoin(num.Int64(1000000)),
-			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(1234567890)},
+			shared.Coin{
+				AssetId: shared.FromSeparate("abra", "cadabra"),
+				Amount:  num.Int64(1234567890),
+			},
 		)
 		if !shared.GreaterThanOrEqual(val1, val2) {
 			t.Fatalf("%v is not greater than %v", val1, val2)
@@ -495,7 +635,12 @@ func Test_ValueChecks(t *testing.T) {
 			t.Fatalf("%v is not less than %v", val4, val3)
 		}
 		if ok, err := shared.Enough(val3, val4); !ok {
-			t.Fatalf("%v does not have enough assets for %v: %v", val4, val3, err.Error())
+			t.Fatalf(
+				"%v does not have enough assets for %v: %v",
+				val4,
+				val3,
+				err.Error(),
+			)
 		}
 		if shared.Equal(val1, val2) {
 			t.Fatalf("%v and %v are equal", val1, val2)
@@ -507,7 +652,10 @@ func Test_ValueChecks(t *testing.T) {
 		val5 := shared.Add(val1, val2)
 		val6 := shared.ValueFromCoins(
 			shared.CreateAdaCoin(num.Int64(2000001)),
-			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(2469135780)},
+			shared.Coin{
+				AssetId: shared.FromSeparate("abra", "cadabra"),
+				Amount:  num.Int64(2469135780),
+			},
 		)
 		if !shared.Equal(val5, val6) {
 			t.Fatalf("%v is not the expected value (%v)", val5, val6)
@@ -515,12 +663,18 @@ func Test_ValueChecks(t *testing.T) {
 
 		val7 := shared.ValueFromCoins(
 			shared.CreateAdaCoin(num.Int64(600000)),
-			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(2345678900)},
+			shared.Coin{
+				AssetId: shared.FromSeparate("abra", "cadabra"),
+				Amount:  num.Int64(2345678900),
+			},
 		)
 		val8 := shared.Subtract(val3, val7)
 		val9 := shared.ValueFromCoins(
 			shared.CreateAdaCoin(num.Int64(400000)),
-			shared.Coin{AssetId: shared.FromSeparate("abra", "cadabra"), Amount: num.Int64(10000000000)},
+			shared.Coin{
+				AssetId: shared.FromSeparate("abra", "cadabra"),
+				Amount:  num.Int64(10000000000),
+			},
 		)
 		if !shared.Equal(val8, val9) {
 			t.Fatalf("%v is not the expected value (%v)", val8, val9)
@@ -595,7 +749,11 @@ func Test_ParseOgmiosMetadataMap(t *testing.T) {
 	err := json.Unmarshal(meta1, &o1)
 	assert.Nil(t, err)
 	labels1 := *(o1.Labels)
-	assert.Equal(t, 0, big.NewInt(1).Cmp(labels1[TestDatumKey].Json.MapField[0].Key.IntField))
+	assert.Equal(
+		t,
+		0,
+		big.NewInt(1).Cmp(labels1[TestDatumKey].Json.MapField[0].Key.IntField),
+	)
 
 	meta2 := json.RawMessage(`
           {
@@ -623,7 +781,11 @@ func Test_ParseOgmiosMetadataMap(t *testing.T) {
 	err = json.Unmarshal(meta2, &o2)
 	assert.Nil(t, err)
 	labels2 := *(o2.Labels)
-	assert.Equal(t, 0, big.NewInt(1).Cmp(labels2[TestDatumKey].Json.MapField[0].Key.IntField))
+	assert.Equal(
+		t,
+		0,
+		big.NewInt(1).Cmp(labels2[TestDatumKey].Json.MapField[0].Key.IntField),
+	)
 }
 
 func Test_GetDatumBytes(t *testing.T) {

--- a/ouroboros/chainsync/num/int.go
+++ b/ouroboros/chainsync/num/int.go
@@ -73,7 +73,9 @@ func (i Int) Uint64() uint64 {
 	return i.BigInt().Uint64()
 }
 
-func (i Int) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (i Int) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	item.N = aws.String(i.BigInt().String())
 	return nil
 }
@@ -114,7 +116,9 @@ func (i Int) Equal(that Int) bool {
 	return i.BigInt().Cmp(that.BigInt()) == 0
 }
 
-func (i *Int) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (i *Int) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	if aws.BoolValue(item.NULL) {
 		return nil
 	}

--- a/ouroboros/chainsync/types.go
+++ b/ouroboros/chainsync/types.go
@@ -55,7 +55,7 @@ type Nonce struct {
 }
 
 type BlockSize struct {
-	Bytes int64 `json:"bytes,omitempty"  dynamodbav:"bytes,omitempty"`
+	Bytes int64 `json:"bytes,omitempty" dynamodbav:"bytes,omitempty"`
 }
 
 type Protocol struct {
@@ -104,8 +104,8 @@ func (p PointString) Point() Point {
 
 type PointStruct struct {
 	Height *uint64 `json:"height,omitempty" dynamodbav:"height,omitempty"` // Not part of RollBackward.
-	ID     string  `json:"id,omitempty"      dynamodbav:"id,omitempty"`    // BLAKE2b_256 hash
-	Slot   uint64  `json:"slot,omitempty"    dynamodbav:"slot,omitempty"`
+	ID     string  `json:"id,omitempty"     dynamodbav:"id,omitempty"`     // BLAKE2b_256 hash
+	Slot   uint64  `json:"slot,omitempty"   dynamodbav:"slot,omitempty"`
 }
 
 func (p PointStruct) Point() Point {
@@ -127,9 +127,18 @@ func (p Point) String() string {
 		return string(p.pointString)
 	case PointTypeStruct:
 		if p.pointStruct.Height == nil {
-			return fmt.Sprintf("slot=%v id=%v", p.pointStruct.Slot, p.pointStruct.ID)
+			return fmt.Sprintf(
+				"slot=%v id=%v",
+				p.pointStruct.Slot,
+				p.pointStruct.ID,
+			)
 		}
-		return fmt.Sprintf("slot=%v id=%v block=%v", p.pointStruct.Slot, p.pointStruct.ID, *p.pointStruct.Height)
+		return fmt.Sprintf(
+			"slot=%v id=%v block=%v",
+			p.pointStruct.Slot,
+			p.pointStruct.ID,
+			*p.pointStruct.Height,
+		)
 	default:
 		return "invalid point"
 	}
@@ -167,12 +176,15 @@ type pointCBOR struct {
 	Struct *PointStruct `cbor:"2,keyasint,omitempty"`
 }
 
-func (p Point) PointType() PointType             { return p.pointType }
+func (p Point) PointType() PointType { return p.pointType }
+
 func (p Point) PointString() (PointString, bool) { return p.pointString, p.pointString != "" }
 
 func (p Point) PointStruct() (*PointStruct, bool) { return p.pointStruct, p.pointStruct != nil }
 
-func (p Point) MarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (p Point) MarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	switch p.pointType {
 	case PointTypeString:
 		item.S = aws.String(string(p.pointString))
@@ -236,7 +248,9 @@ func (p *Point) UnmarshalCBOR(data []byte) error {
 	return nil
 }
 
-func (p *Point) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (p *Point) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	switch {
 	case item == nil:
 		return nil
@@ -263,7 +277,11 @@ func (p *Point) UnmarshalJSON(data []byte) error {
 	case '"':
 		var s string
 		if err := json.Unmarshal(data, &s); err != nil {
-			return fmt.Errorf("failed to unmarshal Point, %v: %w", string(data), err)
+			return fmt.Errorf(
+				"failed to unmarshal Point, %v: %w",
+				string(data),
+				err,
+			)
 		}
 
 		*p = Point{
@@ -274,7 +292,11 @@ func (p *Point) UnmarshalJSON(data []byte) error {
 	default:
 		var ps PointStruct
 		if err := json.Unmarshal(data, &ps); err != nil {
-			return fmt.Errorf("failed to unmarshal Point, %v: %w", string(data), err)
+			return fmt.Errorf(
+				"failed to unmarshal Point, %v: %w",
+				string(data),
+				err,
+			)
 		}
 
 		*p = Point{
@@ -294,20 +316,20 @@ type ProtocolVersion struct {
 
 type RollBackward struct {
 	Direction string            `json:"direction,omitempty" dynamodbav:"direction,omitempty"`
-	Tip       PointStruct       `json:"tip,omitempty"   dynamodbav:"tip,omitempty"`
-	Point     RollBackwardPoint `json:"point,omitempty" dynamodbav:"point,omitempty"`
+	Tip       PointStruct       `json:"tip,omitempty"       dynamodbav:"tip,omitempty"`
+	Point     RollBackwardPoint `json:"point,omitempty"     dynamodbav:"point,omitempty"`
 }
 
 type RollBackwardPoint struct {
-	Slot uint64 `json:"slot,omitempty"    dynamodbav:"slot,omitempty"`
-	ID   string `json:"id,omitempty"      dynamodbav:"id,omitempty"` // BLAKE2b_256 hash
+	Slot uint64 `json:"slot,omitempty" dynamodbav:"slot,omitempty"`
+	ID   string `json:"id,omitempty"   dynamodbav:"id,omitempty"` // BLAKE2b_256 hash
 }
 
 // Assume non-Byron blocks.
 type RollForward struct {
 	Direction string      `json:"direction,omitempty" dynamodbav:"direction,omitempty"`
-	Tip       PointStruct `json:"tip,omitempty"   dynamodbav:"tip,omitempty"`
-	Block     Block       `json:"block,omitempty" dynamodbav:"block,omitempty"`
+	Tip       PointStruct `json:"tip,omitempty"       dynamodbav:"tip,omitempty"`
+	Block     Block       `json:"block,omitempty"     dynamodbav:"block,omitempty"`
 }
 
 func (b Block) PointStruct() PointStruct {
@@ -410,7 +432,12 @@ func (r *ResponsePraos) UnmarshalJSON(b []byte) error {
 
 func (r ResponsePraos) MustFindIntersectResult() ResultFindIntersectionPraos {
 	if r.Method != FindIntersectionMethod {
-		panic(fmt.Errorf("must only use *Must* methods after switching on the findIntersection method; called on %v", r.Method))
+		panic(
+			fmt.Errorf(
+				"must only use *Must* methods after switching on the findIntersection method; called on %v",
+				r.Method,
+			),
+		)
 	}
 	t, ok := r.Result.(ResultFindIntersectionPraos)
 	if ok {
@@ -425,7 +452,12 @@ func (r ResponsePraos) MustFindIntersectResult() ResultFindIntersectionPraos {
 
 func (r ResponsePraos) MustNextBlockResult() ResultNextBlockPraos {
 	if r.Method != NextBlockMethod {
-		panic(fmt.Errorf("must only use *Must* methods after switching on the nextBlock method; called on %v", r.Method))
+		panic(
+			fmt.Errorf(
+				"must only use *Must* methods after switching on the nextBlock method; called on %v",
+				r.Method,
+			),
+		)
 	}
 	t, ok := r.Result.(ResultNextBlockPraos)
 	if ok {
@@ -439,9 +471,9 @@ func (r ResponsePraos) MustNextBlockResult() ResultNextBlockPraos {
 }
 
 type Signature struct {
-	Key               string `json:"key" dynamodbav:"key"`
-	Signature         string `json:"signature" dynamodbav:"signature"`
-	ChainCode         string `json:"chainCode,omitempty" dynamodbav:"chainCode,omitempty"`
+	Key               string `json:"key"                         dynamodbav:"key"`
+	Signature         string `json:"signature"                   dynamodbav:"signature"`
+	ChainCode         string `json:"chainCode,omitempty"         dynamodbav:"chainCode,omitempty"`
 	AddressAttributes string `json:"addressAttributes,omitempty" dynamodbav:"addressAttributes,omitempty"`
 }
 
@@ -500,14 +532,14 @@ func (t TxID) TxHash() string {
 }
 
 type TxIn struct {
-	Transaction TxInID `json:"transaction"  dynamodbav:"transaction"`
-	Index       int    `json:"index" dynamodbav:"index"`
+	Transaction TxInID `json:"transaction" dynamodbav:"transaction"`
+	Index       int    `json:"index"       dynamodbav:"index"`
 }
 
 type TxIns []TxIn
 
 type TxInID struct {
-	ID string `json:"id"  dynamodbav:"id"`
+	ID string `json:"id" dynamodbav:"id"`
 }
 
 func (t TxIn) String() string {
@@ -531,8 +563,8 @@ type TxOuts []TxOut
 type Datums map[string]string
 
 type TxInQuery struct {
-	Transaction shared.UtxoTxID `json:"transaction"  dynamodbav:"transaction"`
-	Index       uint32          `json:"index" dynamodbav:"index"`
+	Transaction shared.UtxoTxID `json:"transaction" dynamodbav:"transaction"`
+	Index       uint32          `json:"index"       dynamodbav:"index"`
 }
 
 func (d *Datums) UnmarshalJSON(i []byte) error {
@@ -570,7 +602,9 @@ func (d *Datums) UnmarshalJSON(i []byte) error {
 	return nil
 }
 
-func (d *Datums) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) error {
+func (d *Datums) UnmarshalDynamoDBAttributeValue(
+	item *dynamodb.AttributeValue,
+) error {
 	if item == nil {
 		return nil
 	}
@@ -596,7 +630,7 @@ func (d *Datums) UnmarshalDynamoDBAttributeValue(item *dynamodb.AttributeValue) 
 
 type Witness struct {
 	Bootstrap  []json.RawMessage `json:"bootstrap,omitempty"  dynamodbav:"bootstrap,omitempty"`
-	Datums     Datums            `json:"datums"     dynamodbav:"datums,omitempty"`
+	Datums     Datums            `json:"datums"               dynamodbav:"datums,omitempty"`
 	Redeemers  json.RawMessage   `json:"redeemers,omitempty"  dynamodbav:"redeemers,omitempty"`
 	Scripts    json.RawMessage   `json:"scripts,omitempty"    dynamodbav:"scripts,omitempty"`
 	Signatures map[string]string `json:"signatures,omitempty" dynamodbav:"signatures,omitempty"`
@@ -722,7 +756,10 @@ func GetMetadataDatums(datums map[string][]byte) ([][]byte, error) {
 	return datumBytes, nil
 }
 
-func GetMetadataDatumsV6(txMetadata json.RawMessage, metadataDatumKey int) ([][]byte, error) {
+func GetMetadataDatumsV6(
+	txMetadata json.RawMessage,
+	metadataDatumKey int,
+) ([][]byte, error) {
 	datums, err := GetMetadataDatumMapV6(txMetadata, metadataDatumKey)
 	if err != nil {
 		return nil, err
@@ -730,7 +767,10 @@ func GetMetadataDatumsV6(txMetadata json.RawMessage, metadataDatumKey int) ([][]
 	return GetMetadataDatums(datums)
 }
 
-func GetMetadataDatumMapV6(txMetadata json.RawMessage, metadataDatumKey int) (map[string][]byte, error) {
+func GetMetadataDatumMapV6(
+	txMetadata json.RawMessage,
+	metadataDatumKey int,
+) (map[string][]byte, error) {
 	// Ogmios will sometimes set the Metadata field to "null" when there's not
 	// any actual metadata. This can lead to unintended errors. If we encounter
 	// this case, just return an empty map.
@@ -750,7 +790,11 @@ func GetMetadataDatumMapV6(txMetadata json.RawMessage, metadataDatumKey int) (ma
 		return nil, nil
 	}
 	if dats.Json == nil {
-		return nil, fmt.Errorf("transaction metadata at key '%d' is missing a json representation: '%v' (is ogmios running with --metadata-detailed-schema?)", metadataDatumKey, string(txMetadata))
+		return nil, fmt.Errorf(
+			"transaction metadata at key '%d' is missing a json representation: '%v' (is ogmios running with --metadata-detailed-schema?)",
+			metadataDatumKey,
+			string(txMetadata),
+		)
 	}
 	return ReconstructDatums(*(dats.Json))
 }
@@ -768,7 +812,9 @@ func ReconstructDatums(metadatum OgmiosMetadatum) (map[string][]byte, error) {
 				switch v.Tag {
 				case OgmiosMetadatumTagList:
 					for _, chunk := range v.ListField {
-						reconstructed = append(reconstructed, chunk.BytesField...)
+						reconstructed = append(
+							reconstructed,
+							chunk.BytesField...)
 					}
 					newDatums[hex.EncodeToString(k.BytesField)] = reconstructed
 				default: // Misformed, ignore

--- a/ouroboros/chainsync/types_test.go
+++ b/ouroboros/chainsync/types_test.go
@@ -36,7 +36,10 @@ import (
 const TestDatumKey = 918273
 
 func TestUnmarshal(t *testing.T) {
-	err := filepath.Walk("../../ext/ogmios/server/test/vectors/NextBlockResponse", assertStructMatchesSchema(t))
+	err := filepath.Walk(
+		"../../ext/ogmios/server/test/vectors/NextBlockResponse",
+		assertStructMatchesSchema(t),
+	)
 	if err != nil {
 		t.Fatalf("got %v; want nil", err)
 	}
@@ -65,7 +68,11 @@ func assertStructMatchesSchema(t *testing.T) filepath.WalkFunc {
 		decoder.DisallowUnknownFields()
 		err = decoder.Decode(&ResponsePraos{})
 		if err != nil {
-			t.Fatalf("got %v; want nil: %v", err, fmt.Sprintf("struct did not match schema for file, %v", path))
+			t.Fatalf(
+				"got %v; want nil: %v",
+				err,
+				fmt.Sprintf("struct did not match schema for file, %v", path),
+			)
 		}
 
 		return nil
@@ -74,7 +81,10 @@ func assertStructMatchesSchema(t *testing.T) filepath.WalkFunc {
 
 func TestDynamodbSerialize(t *testing.T) {
 	t.SkipNow()
-	err := filepath.Walk("../../ext/ogmios/server/test/vectors/NextBlockResponse", assertDynamoDBSerialize(t))
+	err := filepath.Walk(
+		"../../ext/ogmios/server/test/vectors/NextBlockResponse",
+		assertDynamoDBSerialize(t),
+	)
 	assert.Nil(t, err)
 }
 
@@ -116,7 +126,10 @@ func assertDynamoDBSerialize(t *testing.T) filepath.WalkFunc {
 			opts := jsondiff.DefaultConsoleOptions()
 			diff, s := jsondiff.Compare(w, g, &opts)
 
-			if got, want := diff, jsondiff.FullMatch; !reflect.DeepEqual(got, want) {
+			if got, want := diff, jsondiff.FullMatch; !reflect.DeepEqual(
+				got,
+				want,
+			) {
 				fmt.Println(s)
 				assert.EqualValues(t, got, want, "JSON Diff is not full match")
 			}
@@ -279,7 +292,10 @@ func TestPoint_JSON(t *testing.T) {
 		if err != nil {
 			t.Fatalf("got %v; want nil", err)
 		}
-		if got, want := point.PointType(), PointTypeStruct; !reflect.DeepEqual(got, want) {
+		if got, want := point.PointType(), PointTypeStruct; !reflect.DeepEqual(
+			got,
+			want,
+		) {
 			t.Fatalf("got %v; want %v", got, want)
 		}
 
@@ -1427,7 +1443,11 @@ func Test_ParseOgmiosMetadataMapV6(t *testing.T) {
 	err := json.Unmarshal(meta, &o)
 	assert.Nil(t, err)
 	labels := *(o.Labels)
-	assert.Equal(t, 0, big.NewInt(1).Cmp(labels[TestDatumKey].Json.MapField[0].Key.IntField))
+	assert.Equal(
+		t,
+		0,
+		big.NewInt(1).Cmp(labels[TestDatumKey].Json.MapField[0].Key.IntField),
+	)
 }
 
 func Test_GetZapDatumBytesV6(t *testing.T) {
@@ -1477,7 +1497,9 @@ func Test_GetZapDatumBytesV6(t *testing.T) {
 }
 
 func Test_UnmarshalOgmiosMetadataV6(t *testing.T) {
-	meta := json.RawMessage(`{"674":{"map":[{"k":{"string":"msg"},"v":{"list":[{"string":"MuesliSwap Place Order"}]}}]},"1000":{"bytes":"01046034bf780d7e1a39a6ea628c54d70744664111947bfa319072b92d14f063133083b727c9f1b2e83c899982cc66da7aafd748e02206b849"},"1002":{"string":""},"1003":{"string":""},"1004":{"int":-949318},"1005":{"int":2650000},"1007":{"int":1},"1008":{"string":"547ceed647f57e64dc40a29b16be4f36b0d38b5aa3cd7afb286fc094"},"1009":{"string":"6262486f736b79"}}`)
+	meta := json.RawMessage(
+		`{"674":{"map":[{"k":{"string":"msg"},"v":{"list":[{"string":"MuesliSwap Place Order"}]}}]},"1000":{"bytes":"01046034bf780d7e1a39a6ea628c54d70744664111947bfa319072b92d14f063133083b727c9f1b2e83c899982cc66da7aafd748e02206b849"},"1002":{"string":""},"1003":{"string":""},"1004":{"int":-949318},"1005":{"int":2650000},"1007":{"int":1},"1008":{"string":"547ceed647f57e64dc40a29b16be4f36b0d38b5aa3cd7afb286fc094"},"1009":{"string":"6262486f736b79"}}`,
+	)
 	var o OgmiosAuxiliaryDataLabelsV6
 	err := json.Unmarshal(meta, &o)
 	assert.Nil(t, err)

--- a/ouroboros/chainsync/v5/types_test.go
+++ b/ouroboros/chainsync/v5/types_test.go
@@ -48,16 +48,44 @@ func TestV5(t *testing.T) {
 		bootstrap := "{\"key\":\"d88f6028cc3d6d335115de3737bc2fe80a9a57a21a2c7c228ebc33b222e0897b\",\"signature\":\"/rRH7Ka4GfiLS2qsgalyABId1EUb/Mtl9z0x3ilrVALurUKEiAhjOtHUr7+tOi8ZZ85lUWrcpc03NnP3WKnAlg==\",\"chainCode\":\"12340000\",\"addressAttributes\":\"Lw==\"}"
 		assert.Equal(t, "2f", expectedV6.Signatories[0].AddressAttributes)
 		assert.Equal(t, "12340000", expectedV6.Signatories[0].ChainCode)
-		assert.Equal(t, "d88f6028cc3d6d335115de3737bc2fe80a9a57a21a2c7c228ebc33b222e0897b", expectedV6.Signatories[0].Key)
-		assert.Equal(t, "feb447eca6b819f88b4b6aac81a97200121dd4451bfccb65f73d31de296b5402eead42848808633ad1d4afbfad3a2f1967ce65516adca5cd373673f758a9c096", expectedV6.Signatories[0].Signature)
+		assert.Equal(
+			t,
+			"d88f6028cc3d6d335115de3737bc2fe80a9a57a21a2c7c228ebc33b222e0897b",
+			expectedV6.Signatories[0].Key,
+		)
+		assert.Equal(
+			t,
+			"feb447eca6b819f88b4b6aac81a97200121dd4451bfccb65f73d31de296b5402eead42848808633ad1d4afbfad3a2f1967ce65516adca5cd373673f758a9c096",
+			expectedV6.Signatories[0].Signature,
+		)
 		assert.Equal(t, bootstrap, string(v5Conversion.Witness.Bootstrap[0]))
-		assert.Equal(t, "IFb1lTq+ivhYQz6fAoPZQXuGgebeh5fIsM8rocK03mbss8yaUQpf871Qso2aAYaxjDadDHzMfUPRCJDpTyVxQg==", v5Conversion.Witness.Signatures["400019217786c3630fb121c455065b879055aa0ced5076a24abe8d6c837e0318"])
+		assert.Equal(
+			t,
+			"IFb1lTq+ivhYQz6fAoPZQXuGgebeh5fIsM8rocK03mbss8yaUQpf871Qso2aAYaxjDadDHzMfUPRCJDpTyVxQg==",
+			v5Conversion.Witness.Signatures["400019217786c3630fb121c455065b879055aa0ced5076a24abe8d6c837e0318"],
+		)
 		assert.Equal(t, json.RawMessage(network), v5Conversion.Body.Network)
 		assert.Equal(t, json.RawMessage(network), v6Conversion.Network)
-		assert.Equal(t, expectedV6.Signatories[0].AddressAttributes, v6Conversion.Signatories[2].AddressAttributes)
-		assert.Equal(t, expectedV6.Signatories[0].ChainCode, v6Conversion.Signatories[2].ChainCode)
-		assert.Equal(t, expectedV6.Signatories[0].Key, v6Conversion.Signatories[2].Key)
-		assert.Equal(t, expectedV6.Signatories[0].Signature, v6Conversion.Signatories[2].Signature)
+		assert.Equal(
+			t,
+			expectedV6.Signatories[0].AddressAttributes,
+			v6Conversion.Signatories[2].AddressAttributes,
+		)
+		assert.Equal(
+			t,
+			expectedV6.Signatories[0].ChainCode,
+			v6Conversion.Signatories[2].ChainCode,
+		)
+		assert.Equal(
+			t,
+			expectedV6.Signatories[0].Key,
+			v6Conversion.Signatories[2].Key,
+		)
+		assert.Equal(
+			t,
+			expectedV6.Signatories[0].Signature,
+			v6Conversion.Signatories[2].Signature,
+		)
 	})
 }
 
@@ -107,7 +135,11 @@ func Test_ParseOgmiosMetadataMapV5(t *testing.T) {
 	var o OgmiosAuxiliaryDataV5
 	err := json.Unmarshal(meta, &o)
 	assert.Nil(t, err)
-	assert.Equal(t, 0, big.NewInt(1).Cmp(o.Body.Blob[TestDatumKey].MapField[0].Key.IntField))
+	assert.Equal(
+		t,
+		0,
+		big.NewInt(1).Cmp(o.Body.Blob[TestDatumKey].MapField[0].Key.IntField),
+	)
 }
 
 func Test_GetDatumBytesV5(t *testing.T) {
@@ -157,7 +189,9 @@ func Test_GetDatumBytesV5(t *testing.T) {
 }
 
 func Test_UnmarshalOgmiosMetadataV5(t *testing.T) {
-	meta := json.RawMessage(`{"674":{"map":[{"k":{"string":"msg"},"v":{"list":[{"string":"MuesliSwap Place Order"}]}}]},"1000":{"bytes":"01046034bf780d7e1a39a6ea628c54d70744664111947bfa319072b92d14f063133083b727c9f1b2e83c899982cc66da7aafd748e02206b849"},"1002":{"string":""},"1003":{"string":""},"1004":{"int":-949318},"1005":{"int":2650000},"1007":{"int":1},"1008":{"string":"547ceed647f57e64dc40a29b16be4f36b0d38b5aa3cd7afb286fc094"},"1009":{"string":"6262486f736b79"}}`)
+	meta := json.RawMessage(
+		`{"674":{"map":[{"k":{"string":"msg"},"v":{"list":[{"string":"MuesliSwap Place Order"}]}}]},"1000":{"bytes":"01046034bf780d7e1a39a6ea628c54d70744664111947bfa319072b92d14f063133083b727c9f1b2e83c899982cc66da7aafd748e02206b849"},"1002":{"string":""},"1003":{"string":""},"1004":{"int":-949318},"1005":{"int":2650000},"1007":{"int":1},"1008":{"string":"547ceed647f57e64dc40a29b16be4f36b0d38b5aa3cd7afb286fc094"},"1009":{"string":"6262486f736b79"}}`,
+	)
 	var o OgmiosMetadataV5
 	err := json.Unmarshal(meta, &o)
 	assert.Nil(t, err)

--- a/ouroboros/shared/assetId_test.go
+++ b/ouroboros/shared/assetId_test.go
@@ -8,32 +8,76 @@ import (
 )
 
 func Test_AssetID(t *testing.T) {
-	a1 := FromSeparate("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "4c51")
-	a2 := FromSeparate("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "")
+	a1 := FromSeparate(
+		"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		"4c51",
+	)
+	a2 := FromSeparate(
+		"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		"",
+	)
 	a3 := FromSeparate("", "")
 	a4 := AssetID("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24.")
-	a5 := FromSeparate("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "Eeyor3")
-	a6 := FromSeparate("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "e8ada6e5af9fe69685e4bab9")
+	a5 := FromSeparate(
+		"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		"Eeyor3",
+	)
+	a6 := FromSeparate(
+		"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		"e8ada6e5af9fe69685e4bab9",
+	)
 	re1 := regexp.MustCompile(`^[a-fA-F0-9]+\.[a-fA-F0-9]+$`)
 	re2 := regexp.MustCompile(`^[Ee]+yo(r*)(3|E)$`)
 	// a3 := FromSeparate("abcd", "1234")
 	// a4 := FromSeparate("abcd", "")
 
-	assert.EqualValues(t, "da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24.4c51", a1.String())
-	assert.EqualValues(t, "da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", a2.String())
-	assert.EqualValues(t, "da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", a1.PolicyID())
-	assert.EqualValues(t, "da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", a2.PolicyID())
+	assert.EqualValues(
+		t,
+		"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24.4c51",
+		a1.String(),
+	)
+	assert.EqualValues(
+		t,
+		"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		a2.String(),
+	)
+	assert.EqualValues(
+		t,
+		"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		a1.PolicyID(),
+	)
+	assert.EqualValues(
+		t,
+		"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		a2.PolicyID(),
+	)
 	assert.EqualValues(t, "4c51", a1.AssetName())
 	assert.EqualValues(t, "", a2.AssetName())
-	assert.EqualValues(t, true, a1.HasPolicyID("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24"))
+	assert.EqualValues(
+		t,
+		true,
+		a1.HasPolicyID(
+			"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		),
+	)
 	assert.EqualValues(t, false, a1.HasPolicyID("da"))
 	assert.EqualValues(t, false, a1.IsZero())
 	assert.EqualValues(t, true, a1.HasAssetID(re1))
 	assert.EqualValues(t, false, a2.HasAssetID(re1))
-	assert.EqualValues(t, true, a2.HasPolicyID("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24"))
+	assert.EqualValues(
+		t,
+		true,
+		a2.HasPolicyID(
+			"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		),
+	)
 	assert.EqualValues(t, false, a2.IsZero())
 	assert.EqualValues(t, true, a3.IsZero())
-	assert.EqualValues(t, "da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", a4.PolicyID())
+	assert.EqualValues(
+		t,
+		"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+		a4.PolicyID(),
+	)
 	assert.EqualValues(t, "", a4.AssetName())
 	assert.EqualValues(t, false, a4.HasAssetID(re1))
 	regexArray1, found1 := a5.MatchAssetName(re2)

--- a/ouroboros/shared/value.go
+++ b/ouroboros/shared/value.go
@@ -64,7 +64,13 @@ func Enough(have Value, want Value) (bool, error) {
 				haveAmt = haveAssets[assetName]
 			}
 			if haveAmt.LessThan(amt) {
-				return false, fmt.Errorf("not enough %v (%v) to meet demand (%v): %w", assetName, have[policyId][assetName].String(), amt, ErrInsufficientFunds)
+				return false, fmt.Errorf(
+					"not enough %v (%v) to meet demand (%v): %w",
+					assetName,
+					have[policyId][assetName].String(),
+					amt,
+					ErrInsufficientFunds,
+				)
 			}
 		}
 	}

--- a/ouroboros/shared/value_test.go
+++ b/ouroboros/shared/value_test.go
@@ -70,19 +70,58 @@ func Test_AddAsset(t *testing.T) {
 	var v2 Value
 	v2.AddAsset(
 		CreateAdaCoin(num.Uint64(1)),
-		Coin{AssetId: FromSeparate("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "4c51"), Amount: num.Uint64(14310359231)},
+		Coin{
+			AssetId: FromSeparate(
+				"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+				"4c51",
+			),
+			Amount: num.Uint64(14310359231),
+		},
 	)
 	var v3 Value
 	v3.AddAsset(
-		Coin{AssetId: FromSeparate("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "4c51"), Amount: num.Uint64(14310359231)},
+		Coin{
+			AssetId: FromSeparate(
+				"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+				"4c51",
+			),
+			Amount: num.Uint64(14310359231),
+		},
 	)
 
 	assert.EqualValues(t, v1, v2)
 	assert.EqualValues(t, 1, v2.AssetsExceptAdaCount())
 	assert.EqualValues(t, true, v2.IsAdaPresent())
 	assert.EqualValues(t, num.Uint64(1), v2.AssetAmount(AdaAssetID))
-	assert.EqualValues(t, num.Uint64(14310359231), v2.AssetAmount(FromSeparate("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "4c51")))
-	assert.EqualValues(t, num.Uint64(0), v2.AssetAmount(FromSeparate("ea8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "4c51")))
-	assert.EqualValues(t, num.Uint64(0), v2.AssetAmount(FromSeparate("da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24", "4c52")))
+	assert.EqualValues(
+		t,
+		num.Uint64(14310359231),
+		v2.AssetAmount(
+			FromSeparate(
+				"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+				"4c51",
+			),
+		),
+	)
+	assert.EqualValues(
+		t,
+		num.Uint64(0),
+		v2.AssetAmount(
+			FromSeparate(
+				"ea8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+				"4c51",
+			),
+		),
+	)
+	assert.EqualValues(
+		t,
+		num.Uint64(0),
+		v2.AssetAmount(
+			FromSeparate(
+				"da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24",
+				"4c52",
+			),
+		),
+	)
 	assert.EqualValues(t, false, v3.IsAdaPresent())
 }

--- a/state_query.go
+++ b/state_query.go
@@ -67,7 +67,9 @@ func (c *Client) CurrentEpoch(ctx context.Context) (uint64, error) {
 	return content.Result, nil
 }
 
-func (c *Client) CurrentProtocolParameters(ctx context.Context) (json.RawMessage, error) {
+func (c *Client) CurrentProtocolParameters(
+	ctx context.Context,
+) (json.RawMessage, error) {
 	var (
 		payload = makePayload("queryLedgerState/protocolParameters", Map{}, nil)
 		content struct{ Result json.RawMessage }
@@ -80,9 +82,14 @@ func (c *Client) CurrentProtocolParameters(ctx context.Context) (json.RawMessage
 	return content.Result, nil
 }
 
-func (c *Client) CurrentProtocolParametersV5(ctx context.Context) (json.RawMessage, error) {
+func (c *Client) CurrentProtocolParametersV5(
+	ctx context.Context,
+) (json.RawMessage, error) {
 	var (
-		payload = makePayloadV5("Query", Map{"query": "currentProtocolParameters"})
+		payload = makePayloadV5(
+			"Query",
+			Map{"query": "currentProtocolParameters"},
+		)
 		content struct{ Result json.RawMessage }
 	)
 
@@ -93,9 +100,16 @@ func (c *Client) CurrentProtocolParametersV5(ctx context.Context) (json.RawMessa
 	return content.Result, nil
 }
 
-func (c *Client) GenesisConfig(ctx context.Context, era string) (json.RawMessage, error) {
+func (c *Client) GenesisConfig(
+	ctx context.Context,
+	era string,
+) (json.RawMessage, error) {
 	var (
-		payload = makePayload("queryNetwork/genesisConfiguration", Map{"era": era}, nil)
+		payload = makePayload(
+			"queryNetwork/genesisConfiguration",
+			Map{"era": era},
+			nil,
+		)
 		content struct{ Result json.RawMessage }
 	)
 
@@ -195,9 +209,16 @@ func (c *Client) EraStart(ctx context.Context) (statequery.EraStart, error) {
 	return content.Result, nil
 }
 
-func (c *Client) UtxosByAddress(ctx context.Context, addresses ...string) ([]shared.Utxo, error) {
+func (c *Client) UtxosByAddress(
+	ctx context.Context,
+	addresses ...string,
+) ([]shared.Utxo, error) {
 	var (
-		payload = makePayload("queryLedgerState/utxo", Map{"addresses": addresses}, nil)
+		payload = makePayload(
+			"queryLedgerState/utxo",
+			Map{"addresses": addresses},
+			nil,
+		)
 		content struct{ Result []shared.Utxo }
 	)
 
@@ -208,9 +229,16 @@ func (c *Client) UtxosByAddress(ctx context.Context, addresses ...string) ([]sha
 	return content.Result, nil
 }
 
-func (c *Client) UtxosByTxIn(ctx context.Context, txIns ...chainsync.TxInQuery) ([]shared.Utxo, error) {
+func (c *Client) UtxosByTxIn(
+	ctx context.Context,
+	txIns ...chainsync.TxInQuery,
+) ([]shared.Utxo, error) {
 	var (
-		payload = makePayload("queryLedgerState/utxo", Map{"outputReferences": txIns}, nil)
+		payload = makePayload(
+			"queryLedgerState/utxo",
+			Map{"outputReferences": txIns},
+			nil,
+		)
 		content struct{ Result []shared.Utxo }
 	)
 
@@ -236,11 +264,17 @@ type rewardAccountSummary struct {
 	Deposit  *shared.Value `json:"deposit,omitempty"`
 }
 
-func (c *Client) GetDelegation(ctx context.Context, rewardAddress string) (Delegation, error) {
+func (c *Client) GetDelegation(
+	ctx context.Context,
+	rewardAddress string,
+) (Delegation, error) {
 
 	_, data, err := bech32.Decode(rewardAddress)
 	if err != nil {
-		return Delegation{}, fmt.Errorf("failed to decode reward address: %w", err)
+		return Delegation{}, fmt.Errorf(
+			"failed to decode reward address: %w",
+			err,
+		)
 	}
 
 	decoded_value, _ := bech32.ConvertBits(data, 5, 8, false)
@@ -248,22 +282,39 @@ func (c *Client) GetDelegation(ctx context.Context, rewardAddress string) (Deleg
 	rewardAddressVfk := hex.EncodeToString(decoded_value[1:])
 
 	var (
-		payload = makePayload("queryLedgerState/rewardAccountSummaries", Map{"keys": []string{rewardAddress}}, nil)
+		payload = makePayload(
+			"queryLedgerState/rewardAccountSummaries",
+			Map{"keys": []string{rewardAddress}},
+			nil,
+		)
 		content struct {
 			Result map[string]*rewardAccountSummary
 		}
 	)
 
 	if err := c.query(ctx, payload, &content); err != nil {
-		return Delegation{}, fmt.Errorf("failed to query reward account summaries: %w", err)
+		return Delegation{}, fmt.Errorf(
+			"failed to query reward account summaries: %w",
+			err,
+		)
 	}
 
 	summary, ok := content.Result[rewardAddressVfk]
 	if !ok || summary == nil {
 		if !ok {
-			return Delegation{Rewards: num.Int64(0)}, fmt.Errorf("reward account not found for reward address vfk: %s", rewardAddressVfk)
+			return Delegation{
+					Rewards: num.Int64(0),
+				}, fmt.Errorf(
+					"reward account not found for reward address vfk: %s",
+					rewardAddressVfk,
+				)
 		}
-		return Delegation{Rewards: num.Int64(0)}, fmt.Errorf("query returned nil reward account for reward address: %s", rewardAddress)
+		return Delegation{
+				Rewards: num.Int64(0),
+			}, fmt.Errorf(
+				"query returned nil reward account for reward address: %s",
+				rewardAddress,
+			)
 	}
 
 	delegation := Delegation{

--- a/state_query_test.go
+++ b/state_query_test.go
@@ -150,7 +150,10 @@ func TestClient_UtxosByAddress(t *testing.T) {
 
 	ctx := context.Background()
 	client := New(WithEndpoint(endpoint), WithLogger(DefaultLogger))
-	utxos, err := client.UtxosByAddress(ctx, "addr_test1qz6m03tdfm5raxr00fsw7p8v79ptfveaptar9a56zqz09kqkazwhq98h9v8gnk3wm5uvevzvd642zm7778afv0evwqgqfuy84f")
+	utxos, err := client.UtxosByAddress(
+		ctx,
+		"addr_test1qz6m03tdfm5raxr00fsw7p8v79ptfveaptar9a56zqz09kqkazwhq98h9v8gnk3wm5uvevzvd642zm7778afv0evwqgqfuy84f",
+	)
 	if err != nil {
 		t.Fatalf("got %#v; want nil", err)
 	}

--- a/store.go
+++ b/store.go
@@ -61,5 +61,10 @@ func (l *loggingStore) Load(_ context.Context) (chainsync.Points, error) {
 
 type nopStore struct{}
 
-func (n nopStore) Save(context.Context, chainsync.Point) error    { return nil }
-func (n nopStore) Load(context.Context) (chainsync.Points, error) { return nil, nil }
+func (n nopStore) Save(context.Context, chainsync.Point) error { return nil }
+
+func (n nopStore) Load(
+	context.Context,
+) (chainsync.Points, error) {
+	return nil, nil
+}

--- a/tx_evaluation.go
+++ b/tx_evaluation.go
@@ -36,7 +36,11 @@ type EvaluateTx struct {
 	Cbor string `json:"cbor"`
 }
 
-func (c *Client) evaluateTx(ctx context.Context, data string, additionalUtxos []shared.Utxo) (response *EvaluateTxResponse, err error) {
+func (c *Client) evaluateTx(
+	ctx context.Context,
+	data string,
+	additionalUtxos []shared.Utxo,
+) (response *EvaluateTxResponse, err error) {
 	tx := EvaluateTx{
 		Cbor: data,
 	}
@@ -62,11 +66,18 @@ func (c *Client) evaluateTx(ctx context.Context, data string, additionalUtxos []
 // EvaluateTx measures the script execution costs of a transaction.
 // https://ogmios.dev/mini-protocols/local-tx-submission/
 // https://github.com/CardanoSolutions/ogmios/blob/v6.0/docs/content/mini-protocols/local-tx-submission.md
-func (c *Client) EvaluateTx(ctx context.Context, data string) (response *EvaluateTxResponse, err error) {
+func (c *Client) EvaluateTx(
+	ctx context.Context,
+	data string,
+) (response *EvaluateTxResponse, err error) {
 	return c.evaluateTx(ctx, data, nil)
 }
 
-func (c *Client) EvaluateTxWithAdditionalUtxos(ctx context.Context, data string, additionalUtxos []shared.Utxo) (response *EvaluateTxResponse, err error) {
+func (c *Client) EvaluateTxWithAdditionalUtxos(
+	ctx context.Context,
+	data string,
+	additionalUtxos []shared.Utxo,
+) (response *EvaluateTxResponse, err error) {
 	return c.evaluateTx(ctx, data, additionalUtxos)
 }
 
@@ -100,7 +111,11 @@ func readEvaluateTx(data []byte) (r *EvaluateTxResponse, err error) {
 	e, err1 := readEvaluateTxError(data)
 	u, err2 := readEvaluateTxResult(data)
 	if err1 != nil && err2 != nil {
-		return nil, fmt.Errorf("could not parse evaluate tx response; neither error (%w) nor result (%w)", err1, err2)
+		return nil, fmt.Errorf(
+			"could not parse evaluate tx response; neither error (%w) nor result (%w)",
+			err1,
+			err2,
+		)
 	}
 	if err1 == nil {
 		return &EvaluateTxResponse{Error: e}, nil
@@ -108,17 +123,28 @@ func readEvaluateTx(data []byte) (r *EvaluateTxResponse, err error) {
 	if err2 == nil {
 		return &EvaluateTxResponse{ExUnits: u}, nil
 	}
-	return nil, fmt.Errorf("could not parse evaluate tx response: %s", string(data))
+	return nil, fmt.Errorf(
+		"could not parse evaluate tx response: %s",
+		string(data),
+	)
 }
 
 func readEvaluateTxError(data []byte) (*EvaluateTxError, error) {
 	value, _, _, err := jsonparser.Get(data, "error")
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse EvaluateTx error: %w %s", err, data)
+		return nil, fmt.Errorf(
+			"failed to parse EvaluateTx error: %w %s",
+			err,
+			data,
+		)
 	}
 	var e EvaluateTxError
 	if err := json.Unmarshal(value, &e); err != nil {
-		return nil, fmt.Errorf("failed to parse EvaluateTx error: %w %s", err, data)
+		return nil, fmt.Errorf(
+			"failed to parse EvaluateTx error: %w %s",
+			err,
+			data,
+		)
 	}
 	return &e, nil
 }
@@ -126,14 +152,21 @@ func readEvaluateTxError(data []byte) (*EvaluateTxError, error) {
 func readEvaluateTxResult(data []byte) ([]ExUnits, error) {
 	value, dataType, _, err := jsonparser.Get(data, "result")
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse EvaluateTx response: %w %s", err, string(data))
+		return nil, fmt.Errorf(
+			"failed to parse EvaluateTx response: %w %s",
+			err,
+			string(data),
+		)
 	}
 
 	switch dataType {
 	case jsonparser.Array:
 		var results []ExUnits
 		if err := json.Unmarshal(value, &results); err != nil {
-			return nil, fmt.Errorf("failed to parse EvaluateTx response: %w", err)
+			return nil, fmt.Errorf(
+				"failed to parse EvaluateTx response: %w",
+				err,
+			)
 		}
 		return results, nil
 	default:

--- a/tx_submission.go
+++ b/tx_submission.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Response struct {
-	Transaction ResponseTx `json:"transaction,omitempty"  dynamodbav:"transaction,omitempty"`
+	Transaction ResponseTx `json:"transaction,omitempty" dynamodbav:"transaction,omitempty"`
 }
 
 type ResponseTx struct {
@@ -49,13 +49,20 @@ type SubmitTx struct {
 
 // SubmitTx submits the transaction via ogmios
 // https://ogmios.dev/mini-protocols/local-tx-submission/
-func (c *Client) SubmitTx(ctx context.Context, data string) (s *SubmitTxResponse, err error) {
+func (c *Client) SubmitTx(
+	ctx context.Context,
+	data string,
+) (s *SubmitTxResponse, err error) {
 	tx := SubmitTx{
 		Cbor: data,
 	}
 	var (
-		payload = makePayload("submitTransaction", Map{"transaction": tx}, Map{})
-		raw     json.RawMessage
+		payload = makePayload(
+			"submitTransaction",
+			Map{"transaction": tx},
+			Map{},
+		)
+		raw json.RawMessage
 	)
 	if err := c.query(ctx, payload, &raw); err != nil {
 		return nil, fmt.Errorf("failed to submit TX: %w", err)
@@ -68,7 +75,11 @@ func readSubmitTx(data []byte) (r *SubmitTxResponse, err error) {
 	e, err1 := readSubmitTxError(data)
 	id, err2 := readSubmitTxResult(data)
 	if err1 != nil && err2 != nil {
-		return nil, fmt.Errorf("could not parse submit tx response; neither error (%w) nor result (%w)", err1, err2)
+		return nil, fmt.Errorf(
+			"could not parse submit tx response; neither error (%w) nor result (%w)",
+			err1,
+			err2,
+		)
 	}
 	if err1 == nil {
 		return &SubmitTxResponse{Error: e}, nil
@@ -76,7 +87,10 @@ func readSubmitTx(data []byte) (r *SubmitTxResponse, err error) {
 	if err2 == nil {
 		return &SubmitTxResponse{ID: id}, nil
 	}
-	return nil, fmt.Errorf("could not parse submit tx response: %s", string(data))
+	return nil, fmt.Errorf(
+		"could not parse submit tx response: %s",
+		string(data),
+	)
 }
 
 type SubmitTxResponse struct {
@@ -93,11 +107,19 @@ type SubmitTxError struct {
 func readSubmitTxError(data []byte) (*SubmitTxError, error) {
 	value, _, _, err := jsonparser.Get(data, "error")
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse SubmitTx error: %w %s", err, data)
+		return nil, fmt.Errorf(
+			"failed to parse SubmitTx error: %w %s",
+			err,
+			data,
+		)
 	}
 	var e SubmitTxError
 	if err := json.Unmarshal(value, &e); err != nil {
-		return nil, fmt.Errorf("failed to parse SubmitTx error: %w %s", err, data)
+		return nil, fmt.Errorf(
+			"failed to parse SubmitTx error: %w %s",
+			err,
+			data,
+		)
 	}
 	return &e, nil
 }
@@ -105,7 +127,11 @@ func readSubmitTxError(data []byte) (*SubmitTxError, error) {
 func readSubmitTxResult(data []byte) (string, error) {
 	value, dataType, _, err := jsonparser.Get(data, "result")
 	if err != nil {
-		return "", fmt.Errorf("failed to parse SubmitTx response: %w %s", err, string(data))
+		return "", fmt.Errorf(
+			"failed to parse SubmitTx response: %w %s",
+			err,
+			string(data),
+		)
 	}
 
 	switch dataType {
@@ -157,7 +183,10 @@ func (s SubmitTxErrorV5) ErrorCodes() (keys []string, err error) {
 		if bytes.HasPrefix(data, []byte(`"`)) {
 			var key string
 			if err := json.Unmarshal(data, &key); err != nil {
-				return nil, fmt.Errorf("failed to decode string, %v", string(data))
+				return nil, fmt.Errorf(
+					"failed to decode string, %v",
+					string(data),
+				)
 			}
 			keys = append(keys, key)
 			continue
@@ -200,7 +229,10 @@ func readSubmitTxV5(data []byte) error {
 	case jsonparser.Array:
 		var messages []json.RawMessage
 		if err := json.Unmarshal(value, &messages); err != nil {
-			return fmt.Errorf("failed to parse SubmitTx response: array: %w", err)
+			return fmt.Errorf(
+				"failed to parse SubmitTx response: array: %w",
+				err,
+			)
 		}
 		if len(messages) == 0 {
 			return nil

--- a/tx_submission_test.go
+++ b/tx_submission_test.go
@@ -39,7 +39,10 @@ func TestClient_SubmitTx(t *testing.T) {
 }
 
 func TestSubmitTxResult(t *testing.T) {
-	err := filepath.Walk("ext/ogmios/server/test/vectors/SubmitTransactionResponse", testSubmitTxResult(t))
+	err := filepath.Walk(
+		"ext/ogmios/server/test/vectors/SubmitTransactionResponse",
+		testSubmitTxResult(t),
+	)
 	assert.Nil(t, err)
 }
 
@@ -47,7 +50,9 @@ func testSubmitTxResult(t *testing.T) filepath.WalkFunc {
 	return func(path string, info fs.FileInfo, err error) error {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			if err != nil {
-				t.Fatalf("Ogmios files missing. You may need to `rm -rf ext/ogmios/ && git clone git@github.com:CardanoSolutions/ogmios.git ext/ogmios/")
+				t.Fatalf(
+					"Ogmios files missing. You may need to `rm -rf ext/ogmios/ && git clone git@github.com:CardanoSolutions/ogmios.git ext/ogmios/",
+				)
 			}
 			if info.IsDir() {
 				return

--- a/websocket.go
+++ b/websocket.go
@@ -26,7 +26,11 @@ import (
 
 var fault = []byte(`jsonwsp/fault`)
 
-func (c *Client) query(ctx context.Context, payload interface{}, v interface{}) (err error) {
+func (c *Client) query(
+	ctx context.Context,
+	payload interface{},
+	v interface{},
+) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -45,9 +49,17 @@ func (c *Client) query(ctx context.Context, payload interface{}, v interface{}) 
 		}
 	}()
 
-	conn, _, err = websocket.DefaultDialer.DialContext(ctx, c.options.endpoint, nil)
+	conn, _, err = websocket.DefaultDialer.DialContext(
+		ctx,
+		c.options.endpoint,
+		nil,
+	)
 	if err != nil {
-		return fmt.Errorf("failed to connect to ogmios, %v: %w", c.options.endpoint, err)
+		return fmt.Errorf(
+			"failed to connect to ogmios, %v: %w",
+			c.options.endpoint,
+			err,
+		)
 	}
 	defer func() {
 		if v := atomic.AddInt64(&closed, 1); v == 1 {

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -66,7 +66,10 @@ func TestClient_query(t *testing.T) {
 
 	client := New(WithEndpoint(fmt.Sprintf("ws://127.0.0.1:%v", port)))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		250*time.Millisecond,
+	)
 	defer cancel()
 
 	_, err = client.SubmitTx(ctx, "fffefdfc")


### PR DESCRIPTION
Update formatting using `make format golines` to split long lines, align tags, and allow splitting on chained dots. No other code changes other than automatic formatting.