### PR TITLE
build: go 1.24

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SundaeSwap-finance/ogmigo/v6
 
-go 1.19
+go 1.24.0
 
 require (
 	github.com/aws/aws-sdk-go v1.44.197


### PR DESCRIPTION
Go keeps a "back one version" support scheme. With 1.25.0 out, support for 1.23 is being dropped from libraries. Switch to 1.24 for builds everywhere and 1.24/1.25 for CI.